### PR TITLE
Add 'Dream Team' anchor to the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,6 +329,10 @@
                         <li>
                             <a href="https://github.com/users/madiedgar/sponsorship">Support</a>
                         </li>
+                        <li>
+                            <a href="https://github.com/legesher/legesher-dot-io/graphs/contributors">Dream Team</a>
+                        </li>
+                        
                     </ul>
                     <ul class="footer-social-links list-reset">
                         <li>

--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                             <a href="https://github.com/users/madiedgar/sponsorship">Support</a>
                         </li>
                         <li>
-                            <a href="https://github.com/legesher/legesher-dot-io/graphs/contributors">Dream Team</a>
+                            <a href="https://github.com/legesher/legesher/graphs/contributors">Dream Team</a>
                         </li>
                         
                     </ul>


### PR DESCRIPTION
This commit add a 'Dream Team' anchor to the website footer, when clicked it goes to the contributor's page on Github. It closes #17 