### PR TITLE
fix: bug fix for subscribe form is triggered for both Header and Foot…

### DIFF
--- a/src/js/ajax-mailchimp.js
+++ b/src/js/ajax-mailchimp.js
@@ -2,7 +2,8 @@ $(document).ready(function () {
   //  HEADER EMAIL
   var $headerForm = $('#mc-embedded-subscribe-form')
   if ($headerForm.length > 0) {
-    $('form input[type="submit"]').bind('click', function (event) {
+    $('#mc-embedded-subscribe').bind('click', function (event) {
+      console.log('click on header')
       if (event) event.preventDefault()
       registerHeader($headerForm)
     })
@@ -11,7 +12,8 @@ $(document).ready(function () {
   // FOOTER EMAIL
   var $footerForm = $('#mc-embedded-subscribe-form-footer')
   if ($footerForm.length > 0) {
-    $('form input[type="submit"]').bind('click', function (event) {
+    $('#mc-embedded-subscribe-footer').bind('click', function (event) {
+      console.log('click on footer')
       if (event) event.preventDefault()
       registerFooter($footerForm)
     })


### PR DESCRIPTION
…er on a single submit event

w.r.to the issue #58 , I have fixed the issue, tested it in the vercel deployed env.
> Please delete options that are not relevant.

## Title
#58 

This pull request (PR) is made in reference to:  #58 



> What does this PR do?
I have modified the selector which is binded to onclick event for early access button. Previously it was configured as _form input[type="submit"]_ because of which it triggers bothe the header and footer functions. I have modified this to id selector.


> Recommendations for how to test this?
Same steps as described in the issue.


## Motivation and Context

This would help us solve making multiple calls to mailchimp server. When the user enters a correct mail id, the first call will say subscription successful and the second one will say already subscribed. This can be resolved by the changes in this PR.

# Checklist:
<!--- 
[ ] implies unchecked
[x] implies checked
Tick the appropriate boxes (leave if irrelevant)
--->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Testing
<!---
Include any details about your testing process
--->
* [ ] My submission passes the tests?
  - If you did additional testing, please describe in detail how you tested your changes
* [ ] I added new tests for core changes, as applicable?

### Screenshots (if appropriate):
<!--- you can also upload a GIF --->
