### PR TITLE
fix: :bug: #79 update discord invite link on hompage

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://discord.gg/yvsprVf" target="_blank">
+                            <a href="https://discord.gg/DkVjVDP" target="_blank">
                                 <span class="screen-reader-text">Discord</span>
                                 <i class="fab fa-discord"></i>
                             </a>


### PR DESCRIPTION
## fix: discord invite link on homepage

Closes #79 

## Description

Update hyperlink reference for discord button in homepage. 

## Motivation and Context

The previous link had an expired invitation. Users can now join discord with the correct link.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Testing

- [X] My submission passes the tests?
  - Ran a live server and checked if clicking the discord icon redirected to the correct address. 
- [ ] I added new tests for core changes, as applicable?

