### PR TITLE
fix: update redirect link to mailchimp link

### DIFF
--- a/dreamteam.html
+++ b/dreamteam.html
@@ -28,7 +28,7 @@
       width="100%"
       height="100%"
       frameborder="0"
-      src="https://madi357705.typeform.com/to/wzub4R"
+      src="http://eepurl.com/hJo83T"
     ></iframe>
     <script
       type="text/javascript"


### PR DESCRIPTION
we have migrated from typeform to mailchimp in our thank you letter. our `.github` yaml files direct contributors from all repos to the dreamteam.html page. This is how we can update all those instances to the new location. 