### PR TITLE
feat: add Vercel Analytics and fix CSP for Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tanstack/react-query": "^5.79.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
+        "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.2.0",
         "astro": "^5.16.6",
         "class-variance-authority": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "^5.79.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.2.0",
     "astro": "^5.16.6",
     "class-variance-authority": "^0.7.0",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import '@/styles/globals.css';
 import SpeedInsights from '@vercel/speed-insights/astro';
+import Analytics from '@vercel/analytics/astro';
 
 interface Props {
   title: string;
@@ -25,7 +26,7 @@ const {
     <title>{title}</title>
 
     <!-- Security Headers -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https: https://fonts.gstatic.com; connect-src 'self' https://api.buttondown.email;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https: https://fonts.gstatic.com; connect-src 'self' https://api.buttondown.email https://va.vercel-scripts.com https://vitals.vercel-insights.com;" />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
     <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains" />
@@ -43,6 +44,7 @@ const {
     <meta name="twitter:description" content={description} />
 
     <SpeedInsights />
+    <Analytics />
   </head>
   <body class="min-h-screen bg-background antialiased relative">
     <slot />


### PR DESCRIPTION
## Summary
- Add `@vercel/analytics` package for web traffic analytics
- Fix Content-Security-Policy that was blocking Vercel Speed Insights from loading
- Add Analytics component alongside SpeedInsights in Layout

## Changes
- **CSP Updates**: Added `va.vercel-scripts.com` to `script-src` and `connect-src`, plus `vitals.vercel-insights.com` to `connect-src`
- **New Package**: `@vercel/analytics@1.6.1`
- **Layout**: Added `<Analytics />` component

## Why
Speed Insights was showing "No data available" because the existing CSP had `script-src 'self'` which blocked Vercel's external analytics scripts from loading.

## Test plan
- [x] `npm run build` succeeds
- [x] Deploy to Vercel preview
- [ ] Verify Speed Insights dashboard shows data
- [ ] Verify Analytics dashboard shows data

🤖 Generated with [Claude Code](https://claude.com/claude-code)