### PR TITLE
fix: move first_name to metadata for ButtonDown API

### DIFF
--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -133,11 +133,10 @@ export const POST: APIRoute = async ({ request }) => {
       },
       body: JSON.stringify({
         email_address: data.email.trim().toLowerCase(),
-        first_name: data.firstName.trim(),
         ip_address: ip !== 'unknown' ? ip : undefined,
         tags: ['website-subscriber'],
-        // Removed 'status: active' to enable double opt-in
         metadata: {
+          first_name: data.firstName.trim(),
           source: 'website',
           subscribed_at: new Date().toISOString()
         }

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -148,8 +148,18 @@ export const POST: APIRoute = async ({ request }) => {
     if (response.status >= 400) {
       // Log error for debugging (without exposing user data)
       console.error('Buttondown API error:', {
-        status: response.status
+        status: response.status,
+        response: responseData
       });
+
+      // Handle specific ButtonDown errors
+      if (response.status === 400 && responseData?.email_address) {
+        // Email already subscribed or invalid
+        return new Response(
+          JSON.stringify({ message: responseData.email_address[0] || 'Unable to process subscription' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
 
       return new Response(
         JSON.stringify({ message: 'Unable to process subscription at this time' }),

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -148,18 +148,8 @@ export const POST: APIRoute = async ({ request }) => {
     if (response.status >= 400) {
       // Log error for debugging (without exposing user data)
       console.error('Buttondown API error:', {
-        status: response.status,
-        response: responseData
+        status: response.status
       });
-
-      // Handle specific ButtonDown errors
-      if (response.status === 400 && responseData?.email_address) {
-        // Email already subscribed or invalid
-        return new Response(
-          JSON.stringify({ message: responseData.email_address[0] || 'Unable to process subscription' }),
-          { status: 400, headers: { 'Content-Type': 'application/json' } }
-        );
-      }
 
       return new Response(
         JSON.stringify({ message: 'Unable to process subscription at this time' }),


### PR DESCRIPTION
## Summary
- Moves `first_name` from top-level field to inside the `metadata` object when calling ButtonDown API
- ButtonDown API does not accept `first_name` as a top-level field - it was being silently ignored
- First names will now be properly stored with subscribers

## Test plan
- [x] Subscribe with a test email and first name on the website
- [x] Verify in ButtonDown dashboard that the subscriber's metadata contains `first_name`
- [x] Confirm `{{ subscriber.metadata.first_name }}` works in email templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)