### PR TITLE
fix: enable Vercel analytics endpoints in adapter config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,10 @@ export default defineConfig({
   ],
   site: 'https://legesher.io',
   output: 'server',
-  adapter: vercel(),
+  adapter: vercel({
+    webAnalytics: { enabled: true },
+    speedInsights: { enabled: true },
+  }),
   server: {
     headers: {
       'X-Frame-Options': 'DENY'


### PR DESCRIPTION
## Summary
Fix Vercel Analytics and Speed Insights not receiving data by enabling the server-side endpoints in the `@astrojs/vercel` adapter configuration.

## Problem
After PR #118 added the client-side analytics components, no data was appearing in Vercel dashboards despite:
- Scripts loading correctly (200 OK)
- Analytics/Speed Insights enabled in Vercel dashboard
- CSP correctly configured

**Root cause:** The `/_vercel/insights` and `/_vercel/speed-insights/vitals` endpoints returned **404** because the adapter wasn't configured to deploy them.

## Solution
Added `webAnalytics` and `speedInsights` options to the Vercel adapter in `astro.config.mjs`:

```javascript
adapter: vercel({
  webAnalytics: { enabled: true },
  speedInsights: { enabled: true },
}),
```

## Test plan
- [x] `npm run build` succeeds
- [ ] Deploy to Vercel
- [ ] Verify `/_vercel/insights` endpoint returns 200 (not 404)
- [ ] Verify `/_vercel/speed-insights/vitals` endpoint returns 200 (not 404)
- [ ] Check Vercel Analytics dashboard for data
- [ ] Check Vercel Speed Insights dashboard for data

🤖 Generated with [Claude Code](https://claude.com/claude-code)