### PR TITLE
redirect: add newsletter, instagram and linkedin redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,21 @@
       "source": "/go/survey",
       "destination": "https://forms.gle/68A2X73LDT4ZwRPv8",
       "permanent": false
+    },
+    {
+      "source": "/go/newsletter",
+      "destination": "https://buttondown.com/legesher",
+      "permanent": false
+    },
+    {
+      "source": "/go/instagram",
+      "destination": "https://instagram.com/legesher",
+      "permanent": false
+    },
+    {
+      "source": "/go/linkedin",
+      "destination": "https://www.linkedin.com/company/legesher",
+      "permanent": false
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
     },
     {
       "source": "/go/instagram",
-      "destination": "https://instagram.com/legesher",
+      "destination": "https://www.instagram.com/legesher",
       "permanent": false
     },
     {


### PR DESCRIPTION
This pull request adds new redirect routes to the `vercel.json` configuration file. These routes allow users to access external resources via short `/go/*` paths.

New redirect routes:

* Added a redirect from `/go/newsletter` to the Legesher newsletter on Buttondown.
* Added a redirect from `/go/instagram` to the Legesher Instagram page.
* Added a redirect from `/go/linkedin` to the Legesher LinkedIn page.