### PR TITLE
chore(site): post-launch legal polish — security.txt, meta, consent, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Company-wide **Privacy Policy** at [/privacy](https://www.legesher.io/privacy) covering website, products,
+  community, data retention, and full GDPR/CCPA/CPRA/state privacy law disclosures (CORE-542, CORE-581)
+- **Terms of Service** at [/terms](https://www.legesher.io/terms) documenting the open-core licensing
+  model (Apache 2.0 for code; Commercial License for Hosted Services, Curated Datasets, Curriculum),
+  four disclaimers, Delaware governing law, and contact routing (CORE-889)
+- Footer legal row linking to Privacy Policy and Terms of Service site-wide
+- `/.well-known/security.txt` (RFC 9116) exposing `security@legesher.com` as the canonical vulnerability
+  reporting contact
+- Canonical URL and `robots` meta tags on every page for consistent search-engine indexing
+- Explicit GDPR-style opt-in checkbox on the newsletter subscription form linking to the Privacy Policy
+
+### Changed
+
+- Newsletter subscription disclosure clarifies that the visitor IP address is forwarded (server-side) to
+  Buttondown as part of the subscription payload for their spam prevention
+- Layout passes `canonical` and `robots` meta through `Astro.site`; no per-page changes needed
+
+### Removed
+
+- Unused Upstash-based rate limiting from `src/pages/api/subscribe.ts`. The `UPSTASH_REDIS_REST_URL` and
+  `UPSTASH_REDIS_REST_TOKEN` env vars were never configured, so the rate limiter silently fell back to
+  "allow all" &mdash; dead code creating a misleading privacy disclosure. Follow-up tracked in CORE-882
+  to re-add proper rate limiting if spam pressure appears.
+
+### Security
+
+- Privacy Policy documents a zero-cookie posture: no cookies, no `localStorage` writes, no consent banner
+  required under GDPR or the ePrivacy Directive
+- Terms of Service caps liability (greater of twelve-month paid amount or USD $100) and includes AAA
+  arbitration for US users (individual only, no class actions)
+- Dedicated `security@legesher.com` contact route, exposed via `/.well-known/security.txt`
+
 ## [2.0.0] - 2025-12-18
 
 ### Added
+
 - Complete website redesign with Astro 5 + React + Tailwind CSS
 - Newsletter subscription powered by Buttondown API
 - Interactive code editor demo
@@ -16,18 +53,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All-contributors integration with contributor photos
 
 ### Changed
+
 - Migrated from legacy static site to Astro framework
 - Discord community → Slack community
 - Twitter → X branding
 - GitHub Sponsors: personal → Legesher organization
 
 ### Removed
+
 - Unused Vite configuration (Astro handles internally)
 - Unused ESLint configuration
 - Duplicate TypeScript configurations
 - Legacy README
 
 ### Security
+
 - Rate limiting on newsletter API (5 req/hour per IP and email)
 - Honeypot field for bot protection
 - Server-side input validation with XSS prevention

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/.well-known/security.txt` (RFC 9116) exposing `security@legesher.com` as the canonical vulnerability
   reporting contact
 - Canonical URL and `robots` meta tags on every page for consistent search-engine indexing
-- Explicit GDPR-style opt-in checkbox on the newsletter subscription form linking to the Privacy Policy
+- Astro `site` configured to `https://www.legesher.io` (matches the CNAME and the hostname used by
+  security.txt and the privacy/terms docs)
 
 ### Changed
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,7 +28,7 @@ export default defineConfig({
     react(),
     mdx(),
   ],
-  site: 'https://legesher.io',
+  site: 'https://www.legesher.io',
   output: 'server',
   adapter: vercel({
     webAnalytics: { enabled: true },

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,10 @@
+# Legesher security contact (RFC 9116)
+#
+# Report security issues to the contact below. Please do not open public
+# GitHub issues for security vulnerabilities.
+
+Contact: mailto:security@legesher.com
+Expires: 2027-04-20T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://www.legesher.io/.well-known/security.txt
+Policy: https://www.legesher.io/terms

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -65,21 +65,6 @@ import { Button } from "@/components/ui/button";
           aria-hidden="true"
         />
 
-        <label for="consent" class="flex items-start gap-2 text-sm text-muted-foreground mt-2">
-          <input
-            id="consent"
-            type="checkbox"
-            name="consent"
-            required
-            aria-required="true"
-            class="mt-1 flex-shrink-0"
-          />
-          <span class="text-left">
-            I agree to receive the Legesher newsletter and understand I can unsubscribe at any time.
-            See our <a href="/privacy" class="underline hover:text-brand-coral">Privacy Policy</a>.
-          </span>
-        </label>
-
         <Button
           type="submit"
           className="yellow-button mt-2"
@@ -88,7 +73,7 @@ import { Button } from "@/components/ui/button";
         </Button>
       </form>
       <p id="form-message" class="text-sm text-muted-foreground mt-4">
-        Check your email to confirm your subscription. You can unsubscribe at any time.
+        Check your email to confirm your subscription. By subscribing, you agree to receive newsletters. We greatly respect your privacy and you can unsubscribe at any time.
       </p>
     </div>
   </div>

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -65,6 +65,21 @@ import { Button } from "@/components/ui/button";
           aria-hidden="true"
         />
 
+        <label for="consent" class="flex items-start gap-2 text-sm text-muted-foreground mt-2">
+          <input
+            id="consent"
+            type="checkbox"
+            name="consent"
+            required
+            aria-required="true"
+            class="mt-1 flex-shrink-0"
+          />
+          <span class="text-left">
+            I agree to receive the Legesher newsletter and understand I can unsubscribe at any time.
+            See our <a href="/privacy" class="underline hover:text-brand-coral">Privacy Policy</a>.
+          </span>
+        </label>
+
         <Button
           type="submit"
           className="yellow-button mt-2"
@@ -73,7 +88,7 @@ import { Button } from "@/components/ui/button";
         </Button>
       </form>
       <p id="form-message" class="text-sm text-muted-foreground mt-4">
-        Check your email to confirm your subscription. By subscribing, you agree to receive newsletters. We greatly respect your privacy and you can unsubscribe at any time.
+        Check your email to confirm your subscription. You can unsubscribe at any time.
       </p>
     </div>
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,10 +8,13 @@ interface Props {
   description?: string;
 }
 
-const { 
-  title, 
+const {
+  title,
   description = "Legesher is a bridge between the words we speak and the code we write, allowing creation, education, innovation and collaboration to not be lost in translation."
 } = Astro.props;
+
+// Canonical URL resolved against configured site (astro.config.mjs: site = 'https://legesher.io')
+const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://legesher.io').toString();
 ---
 
 <!DOCTYPE html>
@@ -23,6 +26,8 @@ const {
     <link rel="icon" type="image/png" href="/Peggy-Headshot@4x.png" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href={canonicalURL} />
     <title>{title}</title>
 
     <!-- Security Headers - CSP is managed by Astro experimental.csp in astro.config.mjs -->


### PR DESCRIPTION
## Summary

Four small launch-readiness items bundled into a single PR. Follow-up to today's privacy policy ([CORE-542](https://linear.app/legesher/issue/CORE-542) / [CORE-581](https://linear.app/legesher/issue/CORE-581)) and Terms of Service ([CORE-889](https://linear.app/legesher/issue/CORE-889)) launches.

### 1. `/.well-known/security.txt` (RFC 9116)

Canonical machine-readable pointer to `security@legesher.com` for vulnerability reporters. Industry-standard location that security researchers and automated scanners check first.

```text
Contact: mailto:security@legesher.com
Expires: 2027-04-20T00:00:00.000Z
Preferred-Languages: en
Canonical: https://www.legesher.io/.well-known/security.txt
Policy: https://www.legesher.io/terms
```

### 2. Canonical URL + `robots` meta in `Layout.astro`

Every page now emits a canonical URL resolved against `Astro.site` plus an explicit `robots` index directive. Affects all routes including `/privacy` and `/terms` — no per-page edits.

```html
<meta name="robots" content="index,follow" />
<link rel="canonical" href="https://legesher.io/..." />
```

### 3. Explicit consent checkbox on newsletter form

Upgrades the newsletter subscription from implicit consent ("by subscribing, you agree…") to an explicit GDPR-style opt-in checkbox linking to the Privacy Policy. HTML `required` attribute provides browser-level enforcement. Simplified the form-message copy since the consent is now on the checkbox itself.

### 4. `CHANGELOG.md` updated

Ends the 4-month gap between [2.0.0] (2025-12-18) and today. New `[Unreleased]` section documents:

- Privacy Policy + Terms of Service launches
- Footer legal row
- Upstash rate-limiting removal
- Zero-cookie posture commitment
- The four items in this PR

## Why no Linear ticket

These are minor post-launch polish items bundling already-shipped work (CORE-542, CORE-581, CORE-889). Per Madison's preference for single bundled PRs when scope is tightly coupled, I grouped them rather than creating a heavyweight Linear ticket.

## Test plan

- [x] `npm run build` passes locally
- [ ] Vercel preview deploy renders
- [ ] `curl https://<preview>/.well-known/security.txt` returns the file with correct MIME type
- [ ] View-source on `/privacy` and `/terms` shows `<meta name="robots"…>` and `<link rel="canonical"…>`
- [ ] Newsletter form requires checkbox before submit (try submitting unchecked)
- [ ] Privacy Policy link from checkbox navigates to `/privacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)