### PR TITLE
chore(deps): bump GitHub Actions (consolidates #141–#144)

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           issue-inactive-days: 180
           pr-inactive-days: 180

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: |
             Thanks for your contribution!

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pr-message: |
@@ -57,7 +57,7 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             // Check if this is their first merged PR


### PR DESCRIPTION
## Summary

Consolidates the four open Dependabot GitHub Actions version bumps into a single housekeeping PR (your preference: one update, not four individual merges).

| Action | Bump | File |
|---|---|---|
| `actions/github-script` | v7 → v9 | welcome.yml |
| `actions/stale` | v9 → v10 | stale.yml |
| `actions/first-interaction` | v1 → v3 | welcome.yml (×2) |
| `dessant/lock-threads` | v5 → v6 | lock.yml |

CI-only housekeeping — no site or runtime code is affected. These are the community bot workflows (welcome / stale / lock).

Supersedes and closes #141, #142, #143, #144.

Follow-up (tracked in CORE-975): SHA-pin these remaining workflow actions instead of `@vN` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
