### PR TITLE
docs(terms): community-contributed translation data is never sold [CORE-1502]

### DIFF
--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -166,8 +166,7 @@ const lastUpdated = 'July 14, 2026';
           <p>
             <strong>Community-contributed translation data is never sold.</strong> The translations, terminology, and
             review outcomes contributed by our community &mdash; and the language packs built from them &mdash; are
-            released under an open license and are not part of Curated Datasets. We sell what <em>we</em> build; we
-            never sell what the community donates.
+            released under an open license and are not part of Curated Datasets.
           </p>
 
           <h3>5.1 What requires <em>no</em> license (free for all uses)</h3>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 
-const lastUpdated = 'April 20, 2026';
+const lastUpdated = 'July 14, 2026';
 ---
 
 <Layout
@@ -101,9 +101,10 @@ const lastUpdated = 'April 20, 2026';
             </li>
             <li>
               <strong>&ldquo;Curated Datasets&rdquo;</strong> means datasets that <em>we</em> build, compile, and
-              package &mdash; such as benchmarks, evaluation suites, and derived research datasets &mdash; and license
+              package &mdash; such as benchmarks, evaluation suites, and research datasets built from our own
+              work &mdash; and license
               separately from the Open-Source Software. Curated Datasets do <strong>not</strong> include
-              community-contributed translation data, which is published openly (see &sect;5).
+              community-contributed translation data, which is always available under an open license (see &sect;5).
             </li>
             <li>
               <strong>&ldquo;Curriculum&rdquo;</strong> means educational materials, lessons, and courses that we
@@ -164,9 +165,9 @@ const lastUpdated = 'April 20, 2026';
 
           <p>
             <strong>Community-contributed translation data is never sold.</strong> The translations, terminology, and
-            native-speaker reviews contributed by our community &mdash; and the language packs built from them &mdash;
-            are published openly and are not part of Curated Datasets. We license what <em>we</em> build; we do not
-            license what the community donates.
+            review outcomes contributed by our community &mdash; and the language packs built from them &mdash; are
+            released under an open license and are not part of Curated Datasets. We sell what <em>we</em> build; we
+            never sell what the community donates.
           </p>
 
           <h3>5.1 What requires <em>no</em> license (free for all uses)</h3>
@@ -345,8 +346,8 @@ const lastUpdated = 'April 20, 2026';
           <h3>7.3 What a Commercial License covers</h3>
           <p>
             Each Commercial License specifies the licensed activity (e.g., &ldquo;educational use of the Legesher
-            Translation API for up to 10,000 students&rdquo; or &ldquo;commercial access to the Python translation
-            dataset for ML training&rdquo;). Activities outside the scope of your license require a separate
+            Translation API for up to 10,000 students&rdquo; or &ldquo;commercial access to a Legesher-built
+            evaluation benchmark suite&rdquo;). Activities outside the scope of your license require a separate
             agreement.
           </p>
           <p>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -104,7 +104,7 @@ const lastUpdated = 'July 14, 2026';
               package &mdash; such as benchmarks, evaluation suites, and research datasets built from our own
               work &mdash; and license
               separately from the Open-Source Software. Curated Datasets do <strong>not</strong> include
-              community-contributed translation data, which is always available under an open license (see &sect;5).
+              community-contributed translation data, which is never sold (see &sect;5).
             </li>
             <li>
               <strong>&ldquo;Curriculum&rdquo;</strong> means educational materials, lessons, and courses that we

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -100,9 +100,10 @@ const lastUpdated = 'April 20, 2026';
               these Terms plus any service-specific agreement presented to you at sign-up.
             </li>
             <li>
-              <strong>&ldquo;Curated Datasets&rdquo;</strong> means datasets we compile, package, and license
-              separately from the Open-Source Software. Examples include translation corpora sold for ML training and
-              research datasets offered under a commercial data license.
+              <strong>&ldquo;Curated Datasets&rdquo;</strong> means datasets that <em>we</em> build, compile, and
+              package &mdash; such as benchmarks, evaluation suites, and derived research datasets &mdash; and license
+              separately from the Open-Source Software. Curated Datasets do <strong>not</strong> include
+              community-contributed translation data, which is published openly (see &sect;5).
             </li>
             <li>
               <strong>&ldquo;Curriculum&rdquo;</strong> means educational materials, lessons, and courses that we
@@ -159,6 +160,13 @@ const lastUpdated = 'April 20, 2026';
             Legesher is an <strong>open-core</strong> project. The code is free and open source under the Apache 2.0
             License. Hosted Services, Curated Datasets, and Curriculum are licensed commercially to fund the ongoing
             development and community support of the open-source core.
+          </p>
+
+          <p>
+            <strong>Community-contributed translation data is never sold.</strong> The translations, terminology, and
+            native-speaker reviews contributed by our community &mdash; and the language packs built from them &mdash;
+            are published openly and are not part of Curated Datasets. We license what <em>we</em> build; we do not
+            license what the community donates.
           </p>
 
           <h3>5.1 What requires <em>no</em> license (free for all uses)</h3>


### PR DESCRIPTION
The live Terms defined **"Curated Datasets"** with the example *"translation corpora **sold for ML training**"* — while we are about to ask native speakers to donate linguistic expertise into exactly that corpus.

That contradiction is public, and it is the **first thing a careful contributor will find** before deciding whether to contribute. Madison: *"we're not doing that now."*

## Changes

**1. Narrow the "Curated Datasets" definition** (§2) to things *we* build — benchmarks, evaluation suites, derived research datasets — and state explicitly that it **excludes community-contributed translation data**.

**2. Add an explicit commitment** (§5):

> **Community-contributed translation data is never sold.** The translations, terminology, and native-speaker reviews contributed by our community — and the language packs built from them — are published openly and are not part of Curated Datasets. We license what *we* build; we do not license what the community donates.

## What this deliberately does NOT do

It **does not name the open data license** for the corpus (CC-BY-4.0 is recommended but the decision is still open — CORE-1502). The commitment holds regardless of which open license is chosen.

## Context

This is the "gate what we built, never what was donated" principle from the corpus-governance work. It also aligns the Terms with the incoming architecture, where the **corpus** (community options + endorsements) is public and the **canon** (the words we ship) is reviewed in the open.

Related: **CORE-1502** (corpus governance — PII/consent + data license). Note `privacy.astro` **already promises** to update when "user-contributed translations" launch; that update is tracked separately in CORE-1502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)