### PR TITLE
fix(ci): welcome-pr false-red on every PR + group framework majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,20 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # The Astro integrations are version-locked to the Astro core, and React
+      # majors ride with @astrojs/react — shipped as six separate major PRs they
+      # are each individually build-breaking (exactly how #157-#169 piled up).
+      # One group = one coordinated, mergeable upgrade PR.
+      framework-majors:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+        update-types:
+          - "major"
 
   # GitHub Actions (keep SHA-pinned actions current via Dependabot)
   - package-ecosystem: "github-actions"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -20,13 +20,17 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue here!
 
             If you're reporting a bug, please make sure you include steps to reproduce it. We get a lot of issues on this repo, so please be patient and we will get back to you as soon as we can.
 
             To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://docs.legesher.io/the-official-things/contributing-guidelines).
+          # Required input even in an issues-only job (mirror of issue_message
+          # being required in the PR job).
+          pr_message: |
+            Thanks for opening your first pull request here!
 
   welcome-pr:
     if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
@@ -34,13 +38,15 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # first-interaction@v3 requires issue-message even when the job only
-          # ever fires for PRs; omitting it failed this check on EVERY pull
-          # request ("Input required and not supplied: issue_message").
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # first-interaction@v3 renamed every input kebab -> snake_case
+          # (repo_token / issue_message / pr_message). Kebab-case inputs are
+          # silently IGNORED ("Unexpected input(s) 'repo-token', 'pr-message'"),
+          # so the required issue_message read as missing on every PR. Both
+          # messages are required inputs regardless of which event fires.
+          issue_message: |
             Thanks for opening your first issue here!
-          pr-message: |
+          pr_message: |
             Thanks for opening this pull request!
 
             We use [semantic commit messages](https://docs.legesher.io/the-official-things/contributing-guidelines#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix.

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -35,6 +35,11 @@ jobs:
       - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # first-interaction@v3 requires issue-message even when the job only
+          # ever fires for PRs; omitting it failed this check on EVERY pull
+          # request ("Input required and not supplied: issue_message").
+          issue-message: |
+            Thanks for opening your first issue here!
           pr-message: |
             Thanks for opening this pull request!
 


### PR DESCRIPTION
The two root causes behind the 13-PR Dependabot pileup:

1. **`welcome-pr` failed on every PR — and the reason is sneakier than 'a missing input'.** `actions/first-interaction@v3` renamed every input from kebab-case to **snake_case**, and kebab-case inputs are **silently ignored**:

   ```
   Warning: Unexpected input(s) 'repo-token', 'pr-message',
   valid inputs are ['issue_message', 'pr_message', 'repo_token']
   Error: Input required and not supplied: issue_message
   ```

   So `repo-token` and `pr-message` were never reaching the action at all, and the required `issue_message` read as missing on every PR. (The first commit on this branch added `issue-message` in kebab-case — which would have failed identically; the second commit renames all inputs to snake_case in both jobs and supplies both required messages in each.) The red X blocked nothing (no branch protection) but *read* as failing, so green bumps sat unmerged since June.

2. **Majors were ungrouped**, so the Astro-6 cluster arrived as six mutually-unmergeable PRs (the `@astrojs/*` integrations are version-locked to the core). A `framework-majors` group makes the next one arrive as a single coordinated PR.

Companion actions already taken: merged #170/#172/#173/#174, closed #165 + the 8-PR Astro cluster as superseded by #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)