### PR TITLE
docs(privacy): describe how contributed translation data is handled [CORE-1780]

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -302,23 +302,34 @@ const lastUpdated = 'August 10, 2026';
           </p>
           <h3>Contributed translations</h3>
           <p>
-            If you contribute a translation, the word you offer and a record that someone endorsed it are published
-            in the Legesher language corpus, an open research dataset. <strong>Your name is not.</strong> You appear
-            only as an opaque identifier derived from your account name using a secret key, so the published dataset
-            contains no names, handles, or email addresses. The mapping back to you is held privately and is never
-            published.
+            If you contribute a translation, the word you offer and a record that it was endorsed become part of the
+            Legesher language corpus, a research dataset. <strong>Your name does not.</strong> You appear only as an
+            opaque identifier derived from your account name using a secret key, so the dataset contains no names,
+            handles, or email addresses. The mapping back to you is held privately and is never included in any
+            published copy.
+          </p>
+          <p>
+            The corpus is currently distributed privately, with access granted on request, and is intended to become
+            openly available under a Creative Commons Attribution licence. Please contribute on the understanding
+            that the word you offer will eventually be readable by anyone.
           </p>
           <p>
             Credit is opt-in: you are anonymous by default, and your contribution counts the same either way. You may
-            ask us at any time to erase the data that identifies you, and we will &mdash; the translations you offered
-            remain in the dataset as anonymous evidence, because other contributors' work depends on those records,
-            but nothing connects them to you.
+            ask us at any time to erase the data that identifies you. The translations you offered remain in the
+            dataset as anonymous records, because other contributors' work depends on them, but nothing connects
+            them to you.
           </p>
           <p>
-            The full notice, including what we never publish and how withdrawal works, is
-            <a href="https://github.com/legesher/legesher-next/blob/main/CONTRIBUTOR_PRIVACY.md">
-              Your contributions and your data</a>. To be credited, change how you are credited, or withdraw, email
-            <a href="mailto:privacy@legesher.com">privacy@legesher.com</a>.
+            Two limits on that erasure, so you can weigh them before contributing. If you submitted through a public
+            pull request or issue, that submission sits in a public repository under your own account, and we cannot
+            unpublish something you published yourself. And where your details were recorded in our own repository,
+            removing them is a change going forward; earlier revision history is cleared separately rather than on
+            request. Ask us where that stands and we will tell you.
+          </p>
+          <p>
+            To be credited, change how you are credited, withdraw, or read the full contributor notice, email
+            <a href="mailto:privacy@legesher.com">privacy@legesher.com</a>. The notice ships with the project
+            repository and will be linked here directly once that repository is public.
           </p>
           <p>
             Third-party community platforms we link to (GitHub, Slack, LinkedIn, Instagram) are governed by their

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 
-const lastUpdated = 'April 20, 2026';
+const lastUpdated = 'August 10, 2026';
 ---
 
 <Layout
@@ -295,11 +295,30 @@ const lastUpdated = 'April 20, 2026';
         <section aria-labelledby="community">
           <h2 id="community">Community Features</h2>
           <p>
-            Where we host community surfaces &mdash; for example, project showcases, user-contributed translations,
-            or a future "Legesher Home" platform &mdash; additional terms may apply. At the time of this policy's
-            last update, those surfaces are in early development. When they launch, content you submit publicly
-            (for example, a showcase project) will be visible to other community members, and we will update this
-            policy to describe the specific data flows involved.
+            Where we host community surfaces &mdash; for example, project showcases or a future "Legesher Home"
+            platform &mdash; additional terms may apply. Those surfaces are in early development; when they launch,
+            content you submit publicly will be visible to other community members, and we will update this policy
+            to describe the specific data flows involved.
+          </p>
+          <h3>Contributed translations</h3>
+          <p>
+            If you contribute a translation, the word you offer and a record that someone endorsed it are published
+            in the Legesher language corpus, an open research dataset. <strong>Your name is not.</strong> You appear
+            only as an opaque identifier derived from your account name using a secret key, so the published dataset
+            contains no names, handles, or email addresses. The mapping back to you is held privately and is never
+            published.
+          </p>
+          <p>
+            Credit is opt-in: you are anonymous by default, and your contribution counts the same either way. You may
+            ask us at any time to erase the data that identifies you, and we will &mdash; the translations you offered
+            remain in the dataset as anonymous evidence, because other contributors' work depends on those records,
+            but nothing connects them to you.
+          </p>
+          <p>
+            The full notice, including what we never publish and how withdrawal works, is
+            <a href="https://github.com/legesher/legesher-next/blob/main/CONTRIBUTOR_PRIVACY.md">
+              Your contributions and your data</a>. To be credited, change how you are credited, or withdraw, email
+            <a href="mailto:privacy@legesher.com">privacy@legesher.com</a>.
           </p>
           <p>
             Third-party community platforms we link to (GitHub, Slack, LinkedIn, Instagram) are governed by their


### PR DESCRIPTION
The Community Features section committed this policy to being updated when user-contributed translations launched. They have, so the section describes the data flow rather than deferring it.

## Changes

`src/pages/privacy.astro` — new **Contributed translations** subsection covering:

- What is published: the translation offered, and a record that it was endorsed
- What is not: names, handles, email addresses
- How contributors are identified: an opaque value derived from the account name with a secret key; the mapping back is held privately and never published
- Credit is opt-in, with anonymous as the default and no effect on how a contribution counts
- Erasure on request, with the contributed translations remaining as anonymous records
- Links the full contributor notice; names `privacy@legesher.com` as the route

Effective date moved from April 20 to August 10, 2026.

## Verification

`astro build` clean.