### PR TITLE
ci: pin all GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6
         with:
           issue-inactive-days: 180
           pr-inactive-days: 180

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -17,7 +17,7 @@ jobs:
   no-response:
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb # v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           daysUntilClose: 28

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-issue-message: |
             Thanks for your contribution!

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
@@ -36,7 +36,7 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           # first-interaction@v3 renamed every input kebab -> snake_case
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Check if this is their first merged PR


### PR DESCRIPTION
## Summary

Pins every GitHub Actions reference in this repo to a full 40-character commit SHA.

The org-level "require actions to be pinned to a full-length commit SHA" policy rejects unpinned references at job-dispatch time — every job fails during `Set up job` before any project code runs, which presents as a CI outage rather than a lint failure. Pinning here means the policy can be re-enabled without taking this repo's CI down.

## Changes

- All action refs pinned as `@<sha> # <tag>`; the tag comment is kept so Dependabot can still bump them

## Test plan

- All workflow YAML parses
- No unpinned `uses:` references remain
- SHAs resolved from each action's published tag (annotated tags dereferenced to the underlying commit)

## Notes

Pinning only — no version bumps. Every action stays on the same version it was already using, so behavior is unchanged.