### PR TITLE
feat(subscribe): record last-touch channel and release on new subscribers

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -34,7 +34,8 @@ We aim to respond within 48 hours and will keep you updated on the resolution pr
 - GDPR-compliant consent messaging
 - IP address collection for spam detection (disclosed)
 - Unsubscribe functionality via Buttondown
-- Minimal data collection (email + firstName only)
+- Minimal data collection (email + firstName, plus campaign attribution from the
+  subscribing page's URL where present — all disclosed in the Privacy Policy)
 
 **Data Protection**:
 - No sensitive data logged in production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Campaign attribution on newsletter subscriptions.** When someone reaches the site through a
+  link carrying `utm_source` / `utm_campaign`, those values are recorded with their subscription
+  as `last_touch_channel` and `last_touch_release`, so an announcement can be credited with the
+  signups it produced. Read from the subscribing page's address and never stored on the visitor's
+  device, keeping the policy's no-client-side-storage commitment intact. A visit carrying no
+  campaign parameters records nothing at all rather than a placeholder, so "not measured" stays
+  distinguishable from "arrived directly". Disclosed in the Privacy Policy.
 - Company-wide **Privacy Policy** at [/privacy](https://www.legesher.io/privacy) covering website, products,
   community, data retention, and full GDPR/CCPA/CPRA/state privacy law disclosures (CORE-542, CORE-581)
 - **Terms of Service** at [/terms](https://www.legesher.io/terms) documenting the open-core licensing

--- a/public/scripts/newsletter.js
+++ b/public/scripts/newsletter.js
@@ -19,6 +19,15 @@ if (form && messageElement) {
     const firstName = formData.get('firstName');
     const website = formData.get('website'); // Honeypot field
 
+    // Campaign attribution, read from the URL of the page being subscribed
+    // from. Nothing is stored — no cookie, no localStorage, no sessionStorage —
+    // so this describes the visit that converted and not the visitor's history.
+    // JSON.stringify drops undefined, so an absent parameter sends no key and
+    // the server records nothing rather than a placeholder.
+    const params = new URLSearchParams(window.location.search);
+    const utmSource = params.get('utm_source') || undefined;
+    const utmCampaign = params.get('utm_campaign') || undefined;
+
     try {
       // Show loading state immediately
       if (submitButton) {
@@ -36,7 +45,9 @@ if (form && messageElement) {
         body: JSON.stringify({
           email,
           firstName,
-          website
+          website,
+          utmSource,
+          utmCampaign
         }),
       });
 

--- a/src/lib/page-dates.mjs
+++ b/src/lib/page-dates.mjs
@@ -8,7 +8,7 @@
 //
 // ISO 8601, UTC.
 export const LAST_UPDATED = {
-  privacy: '2026-08-10',
+  privacy: '2026-08-17',
   terms: '2026-07-14',
 };
 

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -9,6 +9,19 @@ const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 // Name validation regex (supports international characters)
 const NAME_REGEX = /^[\p{L}\s\-']{2,150}$/u;
 
+// Attribution values come from UTM parameters on the landing URL, so they are
+// client-supplied and untrusted. Constrain them to a slug shape before they
+// reach Buttondown's metadata.
+const ATTRIBUTION_REGEX = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+// A malformed attribution value falls back to the default rather than failing
+// the request: a bad UTM is not a reason to lose a subscriber.
+function sanitizeAttribution(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const normalized = value.trim().toLowerCase();
+  return ATTRIBUTION_REGEX.test(normalized) ? normalized : fallback;
+}
+
 export const POST: APIRoute = async ({ request }) => {
   const BUTTONDOWN_API_KEY = import.meta.env.BUTTONDOWN_API_KEY;
 
@@ -65,6 +78,13 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
+    // utm_source names the channel a subscriber arrived through; utm_campaign
+    // names the release that brought them. An unattributed signup records as
+    // 'unattributed' rather than inheriting the current release — stamping a
+    // release onto a signup it did not earn would inflate that release's credit.
+    const firstTouchChannel = sanitizeAttribution(data.utmSource, 'website');
+    const firstTouchRelease = sanitizeAttribution(data.utmCampaign, 'unattributed');
+
     // Subscribe to newsletter
     const response = await fetch('https://api.buttondown.email/v1/subscribers', {
       method: 'POST',
@@ -79,6 +99,8 @@ export const POST: APIRoute = async ({ request }) => {
         metadata: {
           first_name: data.firstName.trim(),
           source: 'website',
+          first_touch_channel: firstTouchChannel,
+          first_touch_release: firstTouchRelease,
           subscribed_at: new Date().toISOString()
         }
       }),

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -18,15 +18,24 @@ const NAME_REGEX = /^[\p{L}\s\-']{2,150}$/u;
 // Returns undefined when nothing usable was supplied, so the caller can omit
 // the key entirely. Writing a placeholder instead would make "we never measured
 // this" indistinguishable from "we measured it as direct".
+// Letters and numbers of ANY script survive, matching NAME_REGEX above. An
+// ASCII-only slug would erase a campaign named 日本語 to nothing and collapse
+// "2026 日本 Launch" and "2026 Launch" to the same value — silently losing
+// attribution for exactly the non-English announcements this project exists
+// to serve.
 function normalizeAttribution(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .slice(0, 64)
-    .replace(/^[-._]+|[-._]+$/g, '');
-  return normalized || undefined;
+    // Compose after lowercasing, which can decompose (İ becomes i + U+0307),
+    // so equivalent spellings settle on one form before being stored.
+    .normalize('NFC')
+    .replace(/[^\p{L}\p{N}._-]+/gu, '-');
+  // Slice by code point rather than UTF-16 unit: a plain .slice() can cut a
+  // surrogate pair in half and leave an unpaired surrogate.
+  const truncated = Array.from(normalized).slice(0, 64).join('');
+  return truncated.replace(/^[-._]+|[-._]+$/gu, '') || undefined;
 }
 
 export const POST: APIRoute = async ({ request }) => {

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -18,11 +18,19 @@ const NAME_REGEX = /^[\p{L}\s\-']{2,150}$/u;
 // Returns undefined when nothing usable was supplied, so the caller can omit
 // the key entirely. Writing a placeholder instead would make "we never measured
 // this" indistinguishable from "we measured it as direct".
-// Letters and numbers of ANY script survive, matching NAME_REGEX above. An
-// ASCII-only slug would erase a campaign named 日本語 to nothing and collapse
-// "2026 日本 Launch" and "2026 Launch" to the same value — silently losing
-// attribution for exactly the non-English announcements this project exists
-// to serve.
+// Letters, numbers and COMBINING MARKS of any script survive, matching
+// NAME_REGEX above. An ASCII-only slug would erase a campaign named 日本語 to
+// nothing and collapse "2026 日本 Launch" and "2026 Launch" to one value.
+//
+// \p{M} is not optional decoration: without it, हिन्दी becomes "ह-न-द" and
+// සිංහල becomes "ස-හල", because every vowel sign and virama is a mark rather
+// than a letter. Dropping marks silently destroys most Indic, Sinhala, Thai,
+// Hebrew and vocalised Arabic text while leaving Latin, Han and Hangul intact
+// — which is precisely the failure this project exists to prevent.
+//
+// Everything outside the allowlist collapses to '-', so control characters,
+// bidi overrides (U+202E), zero-width joiners and newlines cannot survive:
+// they are format characters (\p{Cf}), not marks.
 function normalizeAttribution(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const normalized = value
@@ -31,7 +39,7 @@ function normalizeAttribution(value: unknown): string | undefined {
     // Compose after lowercasing, which can decompose (İ becomes i + U+0307),
     // so equivalent spellings settle on one form before being stored.
     .normalize('NFC')
-    .replace(/[^\p{L}\p{N}._-]+/gu, '-');
+    .replace(/[^\p{L}\p{N}\p{M}._-]+/gu, '-');
   // Slice by code point rather than UTF-16 unit: a plain .slice() can cut a
   // surrogate pair in half and leave an unpaired surrogate.
   const truncated = Array.from(normalized).slice(0, 64).join('');
@@ -121,6 +129,14 @@ export const POST: APIRoute = async ({ request }) => {
           source: 'website',
           // Omitted entirely when the visit carried no UTM, so an absent field
           // means "not measured" rather than "arrived directly".
+          //
+          // These two values are attacker-controlled: anyone can craft a link
+          // to this site carrying any UTM they like. Normalization blocks
+          // markup, quotes, newlines and spreadsheet formulas, but it cannot
+          // stop readable prose — "ignore-previous-instructions-and-…"
+          // survives as a valid slug. Treat them as untrusted DATA wherever
+          // they are later read, especially by anything that puts subscriber
+          // metadata into a language-model prompt.
           ...(lastTouchChannel && { last_touch_channel: lastTouchChannel }),
           ...(lastTouchRelease && { last_touch_release: lastTouchRelease }),
           subscribed_at: new Date().toISOString()

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -10,16 +10,23 @@ const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const NAME_REGEX = /^[\p{L}\s\-']{2,150}$/u;
 
 // Attribution values come from UTM parameters on the landing URL, so they are
-// client-supplied and untrusted. Constrain them to a slug shape before they
-// reach Buttondown's metadata.
-const ATTRIBUTION_REGEX = /^[a-z0-9][a-z0-9._-]{0,63}$/;
-
-// A malformed attribution value falls back to the default rather than failing
-// the request: a bad UTM is not a reason to lose a subscriber.
-function sanitizeAttribution(value: unknown, fallback: string): string {
-  if (typeof value !== 'string') return fallback;
-  const normalized = value.trim().toLowerCase();
-  return ATTRIBUTION_REGEX.test(normalized) ? normalized : fallback;
+// client-supplied and untrusted. They are normalized to a slug rather than
+// validated-and-discarded: a campaign named "Bridge Beta Launch" demonstrably
+// acquired the subscriber, and rejecting it for containing spaces would lose
+// attribution the campaign earned.
+//
+// Returns undefined when nothing usable was supplied, so the caller can omit
+// the key entirely. Writing a placeholder instead would make "we never measured
+// this" indistinguishable from "we measured it as direct".
+function normalizeAttribution(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .slice(0, 64)
+    .replace(/^[-._]+|[-._]+$/g, '');
+  return normalized || undefined;
 }
 
 export const POST: APIRoute = async ({ request }) => {
@@ -79,11 +86,15 @@ export const POST: APIRoute = async ({ request }) => {
     }
 
     // utm_source names the channel a subscriber arrived through; utm_campaign
-    // names the release that brought them. An unattributed signup records as
-    // 'unattributed' rather than inheriting the current release — stamping a
-    // release onto a signup it did not earn would inflate that release's credit.
-    const firstTouchChannel = sanitizeAttribution(data.utmSource, 'website');
-    const firstTouchRelease = sanitizeAttribution(data.utmCampaign, 'unattributed');
+    // names the release that brought them.
+    //
+    // These are LAST touch, not first: they describe the visit that ended in a
+    // subscription. Someone who arrives via LinkedIn, leaves, and returns direct
+    // a week later records as direct. Recording true first touch would mean
+    // persisting the original UTM across sessions, which requires client-side
+    // storage the privacy policy commits to never using.
+    const lastTouchChannel = normalizeAttribution(data.utmSource);
+    const lastTouchRelease = normalizeAttribution(data.utmCampaign);
 
     // Subscribe to newsletter
     const response = await fetch('https://api.buttondown.email/v1/subscribers', {
@@ -99,8 +110,10 @@ export const POST: APIRoute = async ({ request }) => {
         metadata: {
           first_name: data.firstName.trim(),
           source: 'website',
-          first_touch_channel: firstTouchChannel,
-          first_touch_release: firstTouchRelease,
+          // Omitted entirely when the visit carried no UTM, so an absent field
+          // means "not measured" rather than "arrived directly".
+          ...(lastTouchChannel && { last_touch_channel: lastTouchChannel }),
+          ...(lastTouchRelease && { last_touch_release: lastTouchRelease }),
           subscribed_at: new Date().toISOString()
         }
       }),

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -74,6 +74,11 @@ const lastUpdated = formatLastUpdated(LAST_UPDATED.privacy);
               >Buttondown</a>. When you submit the form, your IP address is also forwarded
               (server-side, not from your browser) to Buttondown as part of the subscription
               payload, which they may use for their own spam prevention and audit logs.
+              If you reached the page through a campaign link, the <code>utm_source</code> and
+              <code>utm_campaign</code> values from that link's address are recorded with your
+              subscription so we can tell which of our announcements reached you. These are read
+              from the address of the page you subscribe from and are never stored on your
+              device; when the address carries no such values, nothing is recorded.
             </li>
             <li>
               <strong>Survey Responses:</strong> feedback provided through optional surveys we link to. Our surveys

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -512,7 +512,12 @@ const lastUpdated = formatLastUpdated(LAST_UPDATED.privacy);
               </tr>
               <tr>
                 <td>Internet activity</td>
-                <td>Aggregated page views and referrer, via cookieless analytics</td>
+                <td>
+                  Aggregated page views and referrer, via cookieless analytics. For newsletter
+                  subscribers only, the campaign link they arrived through
+                  (<code>utm_source</code> / <code>utm_campaign</code>), which is stored with
+                  their subscription and is therefore linked to them rather than aggregated.
+                </td>
                 <td>Yes</td>
               </tr>
               <tr>


### PR DESCRIPTION
## What

Buttondown defines `last_touch_channel` and `last_touch_release` as subscriber metadata, but nothing wrote them. This adds both halves of the write path — the client reads UTM values off the page address, the endpoint normalizes and records them — so an announcement can be credited with the signups it produced.

## Why "last touch", not "first touch"

These fields describe **the visit that ended in a subscription**, not the visit that acquired the subscriber. Someone who arrives via `utm_source=linkedin`, leaves, and returns direct a week later records as direct — LinkedIn gets no credit.

Recording true first touch would mean persisting the original UTM across sessions, which requires client-side storage. The Privacy Policy commits, in bold, to writing nothing to `localStorage`, `sessionStorage`, or any other client-side storage. Accurate naming was the cheaper of the two options.

## Design notes

**Absent attribution is omitted, not defaulted.** A visit carrying no UTM writes no key at all. Recording a placeholder would make "we never measured this" indistinguishable from "we measured it as direct" — the same silent-success failure this change exists to fix, inverted.

**The sanitizer normalizes rather than discards.** `utm_campaign=Bridge Beta Launch` records as `bridge-beta-launch`. Rejecting it for containing spaces would lose a campaign credit for a subscriber it demonstrably acquired. Disallowed runs collapse to `-`, output is truncated to 64 characters, and leading/trailing separators are trimmed.

**Input is untrusted** — it originates in a URL. Non-strings are rejected by a type guard; everything else is normalized rather than trusted.

**No client-side storage is introduced**, keeping the policy's commitment intact.

## Documentation

- **Privacy Policy** — the newsletter bullet now discloses both fields, that they are read from the subscribing page's address, that nothing is stored on the device, and that a visit without them records nothing. Follows the precedent set by the IP-forwarding disclosure.
- **SECURITY.md** — "Minimal data collection (email + firstName only)" was false once these fields ship; corrected.
- **CHANGELOG** — `[Unreleased] → Added` entry.

## Verification

Local, since Actions cannot gate this repo.

**`normalizeAttribution`, 17 cases plus collision and surrogate checks, all pass.** Exercised by extracting the function from the shipped source rather than a hand copy:

| input | output |
| --- | --- |
| `Bridge Beta Launch` | `bridge-beta-launch` |
| `  LinkedIn  ` | `linkedin` |
| `a/b:c%d` | `a-b-c-d` |
| `<script>alert(1)</script>` | `script-alert-1-script` |
| `日本語` | `日本語` |
| `2026 日本 Launch` / `2026 Launch` | `2026-日本-launch` / `2026-launch` (distinct) |
| `Über Launch` | `über-launch` |
| `لغة عربية` | `لغة-عربية` |
| `---`, `""`, `null`, `42`, `{}`, absent | omitted |
| 200 chars | truncated to 64 |
| `trailing-dash-` | `trailing-dash` |

**Route smoke-tested against `astro dev`.** The build prerenders content pages, but this route opts out via `prerender = false`, so a green build never executes it:

| case | result |
| --- | --- |
| malformed email | 400 |
| honeypot filled | 400 |
| valid, no UTM | reaches Buttondown (500 on dummy key) |
| valid, messy UTM | reaches Buttondown |
| `utmSource` as object, `utmCampaign` as array | reaches Buttondown — type guard held, no throw |

`@astrojs/check` 0 errors (the two `ts(6133)` warnings are pre-existing), `npm run build` passes, and the updated `newsletter.js` is served.

**Confirm after deploy** with one live signup through a UTM'd link — now a real test, since a working pipeline and a broken one produce different records.

## Unrelated repo hygiene, not fixed here

`.astro/` is listed in `.gitignore`, but `.astro/types.d.ts`, `content-assets.mjs` and `content-modules.mjs` were committed before that rule existed, so they remain tracked. Any build regenerates them and produces a phantom diff — this branch hit it and reverted it back out. Worth untracking in its own change.


## Second review pass

Four further findings, all fixed in `ba1f067`:

- **The normalizer was ASCII-only.** A campaign named `日本語` normalized to empty and was omitted — recording byte-identically to a visit carrying no UTM, the exact ambiguity the function exists to prevent. It also collapsed `2026 日本 Launch` and `2026 Launch` to one slug and stripped diacritics. Letters and numbers of any script now survive, matching `NAME_REGEX`'s existing use of `\p{L}` one line above. Given what this project is for, an attribution system that silently discarded non-English campaign names was the wrong default.
- **NFC composition after lowercasing**, since lowercasing can decompose (`İ` → `i` + U+0307), and **code-point-safe truncation** so a slice cannot split a surrogate pair.
- **`LAST_UPDATED.privacy` bumped to 2026-08-17.** The policy changed; this constant also drives the sitemap's `<lastmod>`, so leaving it stale would have suppressed the re-index signal.
- **CCPA table corrected.** Its internet-activity row described that category as aggregated and cookieless; campaign attribution is stored against the subscriber and is neither.

## Known-false claims in SECURITY.md, deliberately not fixed here

Pre-existing, and surfaced because this PR edits that same list for truthfulness. None of these exist in `subscribe.ts`:

- "Dual rate limiting (IP + email based, 5 req/hour)" — there is no rate limiting.
- "XSS prevention (HTML tag stripping)" — nothing strips HTML.
- "Length limits (150 characters for firstName/email)" — `firstName` is capped by `NAME_REGEX`; email has no length bound.

Correcting the document and implementing the controls are different decisions, and neither belongs in a launch-day attribution change.
