### PR TITLE
feat(site): language support and language canon pages [CORE-1929] [CORE-1930]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Language support page** at [/languages](https://www.legesher.io/languages) listing every human language
+  Legesher ships a Python language pack for, the maturity stamp each one carries, and what moves a language
+  up the ladder. Every language is `experimental` today and the page says so plainly rather than presenting
+  a ladder and letting a reader assume the languages are spread across it. Promotion criteria are described
+  as still being defined with the language communities, because they are — no threshold is implied.
+  (CORE-1929)
+- **Language canon page** at [/canon](https://www.legesher.io/canon) covering the dataset of vocabulary
+  Legesher actually ships, and answering "how is this different from the corpus?" at the top of the page
+  rather than leaving a reader to compare two dataset cards. Links both artifacts, each labelled for who it
+  is for: the canon for developers, the corpus for researchers. (CORE-1930)
+- Language and tier data is **generated, not hand-written**. `npm run sync:languages` derives
+  `src/data/language-packs.json` from the language registry and the pack export's own manifest — the same
+  two inputs the published dataset is built from — and fails if the two disagree about which locales exist
+  or how they are distributed across the ladder. The counts and stamps rendered on both pages are read from
+  that file, so the site cannot advertise a review standard the packs no longer hold. (CORE-1929)
 - **Campaign attribution on newsletter subscriptions.** When someone reaches the site through a
   link carrying `utm_source` / `utm_campaign`, those values are recorded with their subscription
   as `last_touch_channel` and `last_touch_release`, so an announcement can be credited with the

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "contributors:generate": "all-contributors generate"
+    "contributors:generate": "all-contributors generate",
+    "sync:languages": "node scripts/sync-language-data.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^6.0.3",

--- a/scripts/sync-language-data.mjs
+++ b/scripts/sync-language-data.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Regenerates src/data/language-packs.json — the site's copy of which human
+// languages ship a Legesher language pack, and what tier each one carries.
+//
+// WHY A GENERATED FILE, AND NOT A HAND-WRITTEN LIST
+//
+// The tier stamped on a language is a claim about how far that language has
+// been reviewed, and the same claim is stamped on the published dataset. A
+// hand-typed list on the website is how those two silently stop agreeing: the
+// dataset re-exports, the site does not, and the site is then advertising a
+// review standard the packs no longer hold. So the site's copy is derived,
+// once, from the artifacts that decide the answer, and the derivation is
+// re-runnable.
+//
+// INPUTS — both JSON, both produced by the packs monorepo, never edited here:
+//
+//   1. The language registry (`libs/i18n/legesher_i18n/languages.json`). Itself
+//      generated from the translations database; carries each locale's name,
+//      endonym, direction, and `status` — the tier.
+//   2. The canon export manifest (`manifest.json`, written beside the parquet
+//      files by the pack exporter). Carries the counts that actually ship:
+//      locales, pack files, vocabulary rows, interpreter versions, and the
+//      tier spread.
+//
+// Two inputs rather than one because neither alone is sufficient: the registry
+// knows the languages, the manifest knows what was published about them. They
+// are cross-checked against each other below, so a stale pairing fails here
+// instead of rendering a wrong number.
+//
+// The parquet files are deliberately not read. Everything the site renders is
+// in the manifest, and adding a parquet dependency to a static site build to
+// re-derive numbers the exporter already reconciled would buy nothing.
+//
+// Both paths are required rather than guessed, because the wrong pairing is
+// worse than no run at all:
+//
+//   npm run sync:languages -- \
+//     --registry <monorepo>/libs/i18n/legesher_i18n/languages.json \
+//     --manifest <monorepo>/build/hf-packs/manifest.json
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT = resolve(REPO_ROOT, 'src/data/language-packs.json');
+
+const USAGE =
+  'Usage: npm run sync:languages -- \\\n' +
+  '  --registry <monorepo>/libs/i18n/legesher_i18n/languages.json \\\n' +
+  '  --manifest <monorepo>/build/hf-packs/manifest.json';
+
+function parseArgs(argv) {
+  const args = { registry: null, manifest: null };
+  for (let i = 0; i < argv.length; i += 2) {
+    const flag = argv[i]?.replace(/^--/, '');
+    if (!(flag in args)) {
+      throw new Error(`Unknown argument "${argv[i]}".\n${USAGE}`);
+    }
+    if (argv[i + 1] === undefined) throw new Error(`--${flag} needs a path.\n${USAGE}`);
+    args[flag] = argv[i + 1];
+  }
+  for (const [flag, value] of Object.entries(args)) {
+    if (!value) throw new Error(`--${flag} is required.\n${USAGE}`);
+  }
+  return args;
+}
+
+function readJson(label, path) {
+  const absolute = resolve(REPO_ROOT, path);
+  try {
+    return JSON.parse(readFileSync(absolute, 'utf8'));
+  } catch (error) {
+    throw new Error(
+      `Could not read the ${label} at ${absolute}.\n` +
+        `Point --${label} at a checkout of the packs monorepo` +
+        (label === 'manifest' ? ', running the pack export first if needed' : '') +
+        `.\n  ${error.message}\n${USAGE}`
+    );
+  }
+}
+
+/** Fail loudly when the two inputs describe different exports. */
+function crossCheck(registry, manifest) {
+  const registryCodes = Object.keys(registry).sort();
+  const manifestCodes = [...manifest.locales].sort();
+
+  const onlyInRegistry = registryCodes.filter((c) => !manifestCodes.includes(c));
+  const onlyInManifest = manifestCodes.filter((c) => !registryCodes.includes(c));
+  if (onlyInRegistry.length || onlyInManifest.length) {
+    throw new Error(
+      'Registry and export manifest name different locales — one of them is stale.\n' +
+        `  only in registry: ${onlyInRegistry.join(', ') || '(none)'}\n` +
+        `  only in manifest: ${onlyInManifest.join(', ') || '(none)'}`
+    );
+  }
+
+  if (manifest.counts.locales !== registryCodes.length) {
+    throw new Error(
+      `Manifest counts ${manifest.counts.locales} locales but names ${registryCodes.length}.`
+    );
+  }
+
+  // The tier a language carries is read from the registry below, while the
+  // headline "all of them are experimental" line is read from the manifest.
+  // Proving the two agree here is what lets the pages trust either one.
+  const derived = {};
+  for (const code of registryCodes) {
+    const tier = registry[code].status;
+    if (!tier) throw new Error(`Language "${code}" carries no status in the registry.`);
+    derived[tier] = (derived[tier] ?? 0) + 1;
+  }
+  const declared = manifest.tier_counts ?? {};
+  const tiers = [...new Set([...Object.keys(derived), ...Object.keys(declared)])].sort();
+  const disagreement = tiers.filter((tier) => derived[tier] !== declared[tier]);
+  if (disagreement.length) {
+    throw new Error(
+      'Tier spread differs between the registry and the export manifest:\n' +
+        disagreement
+          .map((t) => `  ${t}: registry ${derived[t] ?? 0}, manifest ${declared[t] ?? 0}`)
+          .join('\n')
+    );
+  }
+
+  return derived;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const registry = readJson('registry', args.registry).languages;
+  const manifest = readJson('manifest', args.manifest);
+
+  const tierCounts = crossCheck(registry, manifest);
+
+  const languages = Object.entries(registry)
+    .map(([code, meta]) => ({
+      code,
+      name: meta.name,
+      native: meta.native,
+      rtl: Boolean(meta.rtl),
+      tier: meta.status,
+    }))
+    // Sorted by English name so the rendered table needs no sort of its own.
+    .sort((a, b) => a.name.localeCompare(b.name, 'en'));
+
+  const data = {
+    _comment:
+      'GENERATED FILE — do not edit by hand. Regenerate with `npm run sync:languages`. ' +
+      'Source: the language registry and the canon export manifest in the packs monorepo.',
+    artifact: manifest.artifact,
+    layer: manifest.layer,
+    license: manifest.declared_license,
+    counts: {
+      locales: manifest.counts.locales,
+      packFiles: manifest.counts.pack_files,
+      vocabularyRows: manifest.counts.vocabulary_rows,
+      pythonVersions: manifest.counts.python_versions,
+    },
+    tierCounts,
+    languages,
+  };
+
+  mkdirSync(dirname(OUTPUT), { recursive: true });
+  writeFileSync(OUTPUT, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+
+  const spread = Object.entries(tierCounts)
+    .map(([tier, count]) => `${count} ${tier}`)
+    .join(', ');
+  console.log(
+    `Wrote ${OUTPUT}\n` +
+      `  ${data.counts.locales} languages (${spread}), ` +
+      `${data.counts.packFiles} pack files, ` +
+      `${data.counts.vocabularyRows.toLocaleString('en-US')} rows`
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/scripts/sync-language-data.mjs
+++ b/scripts/sync-language-data.mjs
@@ -80,6 +80,38 @@ function readJson(label, path) {
   }
 }
 
+/**
+ * Fail with a sentence naming the field, not a stack trace about `undefined`.
+ *
+ * Both inputs are generated files from another repository, so the realistic
+ * failure is being handed the wrong file rather than a corrupt one — and the
+ * useful error says which shape was expected.
+ */
+function requireShape(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function validateInputs(registryFile, manifest) {
+  requireShape(
+    registryFile && typeof registryFile === 'object' && registryFile.languages,
+    'The registry file has no `languages` object. Expected the generated ' +
+      'languages.json from the packs monorepo, not another JSON file.'
+  );
+  requireShape(
+    Array.isArray(manifest?.locales),
+    'The manifest has no `locales` array. Expected manifest.json from a pack ' +
+      'export, not another JSON file.'
+  );
+  requireShape(
+    Number.isInteger(manifest?.counts?.locales),
+    'The manifest has no `counts.locales` integer. Expected manifest.json from a pack export.'
+  );
+  requireShape(
+    new Set(manifest.locales).size === manifest.locales.length,
+    'The manifest lists the same locale more than once, so its counts cannot be trusted.'
+  );
+}
+
 /** Fail loudly when the two inputs describe different exports. */
 function crossCheck(registry, manifest) {
   const registryCodes = Object.keys(registry).sort();
@@ -112,7 +144,10 @@ function crossCheck(registry, manifest) {
   }
   const declared = manifest.tier_counts ?? {};
   const tiers = [...new Set([...Object.keys(derived), ...Object.keys(declared)])].sort();
-  const disagreement = tiers.filter((tier) => derived[tier] !== declared[tier]);
+  // Both sides default to 0 before comparing. A manifest is free to declare a
+  // rung explicitly as zero, and comparing `undefined` to `0` would reject it
+  // with the self-contradicting message "registry 0, manifest 0".
+  const disagreement = tiers.filter((tier) => (derived[tier] ?? 0) !== (declared[tier] ?? 0));
   if (disagreement.length) {
     throw new Error(
       'Tier spread differs between the registry and the export manifest:\n' +
@@ -127,14 +162,22 @@ function crossCheck(registry, manifest) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const registry = readJson('registry', args.registry).languages;
+  const registryFile = readJson('registry', args.registry);
   const manifest = readJson('manifest', args.manifest);
+  validateInputs(registryFile, manifest);
 
+  const registry = registryFile.languages;
   const tierCounts = crossCheck(registry, manifest);
 
   const languages = Object.entries(registry)
     .map(([code, meta]) => ({
       code,
+      // The registry key and the BCP 47 tag are not the same string for every
+      // language — `zh` is `zh-Hans`, `no` is `nb` — and they answer different
+      // questions. The key identifies the pack; the tag tells a browser or a
+      // screen reader which language the text is in. Both are carried so the
+      // page can render the key and mark up the tag.
+      bcp47: meta.bcp47 || code,
       name: meta.name,
       native: meta.native,
       rtl: Boolean(meta.rtl),

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -46,7 +46,9 @@ const currentYear = new Date().getFullYear();
         </a>
       </div>
       <div class="text-sm text-brand-gray flex flex-col md:items-end gap-1">
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 md:justify-end">
+          <a href="/languages" class="hover:text-brand-cyan transition-colors duration-300">Language Support</a>
+          <a href="/canon" class="hover:text-brand-cyan transition-colors duration-300">Language Canon</a>
           <a href="/privacy" class="hover:text-brand-cyan transition-colors duration-300">Privacy Policy</a>
           <a href="/terms" class="hover:text-brand-cyan transition-colors duration-300">Terms of Service</a>
         </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,6 +5,7 @@ import { LINKS } from '@/lib/links';
 // Single source for both the desktop nav and the mobile menu so the two can't
 // drift apart as links are added.
 const navLinks = [
+  { href: '/languages', label: 'Languages' },
   { href: LINKS.github, label: 'Roadmap' },
   { href: LINKS.slack, label: 'Community' },
   { href: LINKS.docs, label: 'Docs' },

--- a/src/data/language-packs.json
+++ b/src/data/language-packs.json
@@ -15,6 +15,7 @@
   "languages": [
     {
       "code": "am",
+      "bcp47": "am",
       "name": "Amharic",
       "native": "አማርኛ",
       "rtl": false,
@@ -22,6 +23,7 @@
     },
     {
       "code": "ar",
+      "bcp47": "ar",
       "name": "Arabic",
       "native": "العربية",
       "rtl": true,
@@ -29,6 +31,7 @@
     },
     {
       "code": "bn",
+      "bcp47": "bn",
       "name": "Bengali",
       "native": "বাংলা",
       "rtl": false,
@@ -36,6 +39,7 @@
     },
     {
       "code": "bs",
+      "bcp47": "bs",
       "name": "Bosnian",
       "native": "Bosanski",
       "rtl": false,
@@ -43,6 +47,7 @@
     },
     {
       "code": "my",
+      "bcp47": "my",
       "name": "Burmese",
       "native": "မြန်မာ",
       "rtl": false,
@@ -50,6 +55,7 @@
     },
     {
       "code": "ca",
+      "bcp47": "ca",
       "name": "Catalan",
       "native": "Català",
       "rtl": false,
@@ -57,6 +63,7 @@
     },
     {
       "code": "zh",
+      "bcp47": "zh-Hans",
       "name": "Chinese",
       "native": "中文",
       "rtl": false,
@@ -64,6 +71,7 @@
     },
     {
       "code": "hr",
+      "bcp47": "hr",
       "name": "Croatian",
       "native": "Hrvatski",
       "rtl": false,
@@ -71,6 +79,7 @@
     },
     {
       "code": "cs",
+      "bcp47": "cs",
       "name": "Czech",
       "native": "Čeština",
       "rtl": false,
@@ -78,6 +87,7 @@
     },
     {
       "code": "da",
+      "bcp47": "da",
       "name": "Danish",
       "native": "Dansk",
       "rtl": false,
@@ -85,6 +95,7 @@
     },
     {
       "code": "nl",
+      "bcp47": "nl",
       "name": "Dutch",
       "native": "Nederlands",
       "rtl": false,
@@ -92,6 +103,7 @@
     },
     {
       "code": "en",
+      "bcp47": "en",
       "name": "English",
       "native": "English",
       "rtl": false,
@@ -99,6 +111,7 @@
     },
     {
       "code": "fi",
+      "bcp47": "fi",
       "name": "Finnish",
       "native": "Suomi",
       "rtl": false,
@@ -106,6 +119,7 @@
     },
     {
       "code": "fr",
+      "bcp47": "fr",
       "name": "French",
       "native": "Français",
       "rtl": false,
@@ -113,6 +127,7 @@
     },
     {
       "code": "gl",
+      "bcp47": "gl",
       "name": "Galician",
       "native": "Galego",
       "rtl": false,
@@ -120,6 +135,7 @@
     },
     {
       "code": "de",
+      "bcp47": "de",
       "name": "German",
       "native": "Deutsch",
       "rtl": false,
@@ -127,6 +143,7 @@
     },
     {
       "code": "el",
+      "bcp47": "el",
       "name": "Greek",
       "native": "Ελληνικά",
       "rtl": false,
@@ -134,6 +151,7 @@
     },
     {
       "code": "gu",
+      "bcp47": "gu",
       "name": "Gujarati",
       "native": "ગુજરાતી",
       "rtl": false,
@@ -141,6 +159,7 @@
     },
     {
       "code": "he",
+      "bcp47": "he",
       "name": "Hebrew",
       "native": "עברית",
       "rtl": true,
@@ -148,6 +167,7 @@
     },
     {
       "code": "hi",
+      "bcp47": "hi",
       "name": "Hindi",
       "native": "हिन्दी",
       "rtl": false,
@@ -155,6 +175,7 @@
     },
     {
       "code": "hu",
+      "bcp47": "hu",
       "name": "Hungarian",
       "native": "Magyar",
       "rtl": false,
@@ -162,6 +183,7 @@
     },
     {
       "code": "id",
+      "bcp47": "id",
       "name": "Indonesian",
       "native": "Bahasa Indonesia",
       "rtl": false,
@@ -169,6 +191,7 @@
     },
     {
       "code": "ga",
+      "bcp47": "ga",
       "name": "Irish",
       "native": "Gaeilge",
       "rtl": false,
@@ -176,6 +199,7 @@
     },
     {
       "code": "it",
+      "bcp47": "it",
       "name": "Italian",
       "native": "Italiano",
       "rtl": false,
@@ -183,6 +207,7 @@
     },
     {
       "code": "ja",
+      "bcp47": "ja",
       "name": "Japanese",
       "native": "日本語",
       "rtl": false,
@@ -190,6 +215,7 @@
     },
     {
       "code": "kn",
+      "bcp47": "kn",
       "name": "Kannada",
       "native": "ಕನ್ನಡ",
       "rtl": false,
@@ -197,6 +223,7 @@
     },
     {
       "code": "ko",
+      "bcp47": "ko",
       "name": "Korean",
       "native": "한국어",
       "rtl": false,
@@ -204,6 +231,7 @@
     },
     {
       "code": "lv",
+      "bcp47": "lv",
       "name": "Latvian",
       "native": "Latviešu",
       "rtl": false,
@@ -211,6 +239,7 @@
     },
     {
       "code": "mk",
+      "bcp47": "mk",
       "name": "Macedonian",
       "native": "Македонски",
       "rtl": false,
@@ -218,6 +247,7 @@
     },
     {
       "code": "ms",
+      "bcp47": "ms",
       "name": "Malay",
       "native": "Bahasa Melayu",
       "rtl": false,
@@ -225,6 +255,7 @@
     },
     {
       "code": "ml",
+      "bcp47": "ml",
       "name": "Malayalam",
       "native": "മലയാളം",
       "rtl": false,
@@ -232,6 +263,7 @@
     },
     {
       "code": "mn",
+      "bcp47": "mn-Cyrl",
       "name": "Mongolian",
       "native": "Монгол",
       "rtl": false,
@@ -239,6 +271,7 @@
     },
     {
       "code": "no",
+      "bcp47": "nb",
       "name": "Norwegian",
       "native": "Norsk",
       "rtl": false,
@@ -246,6 +279,7 @@
     },
     {
       "code": "fa",
+      "bcp47": "fa",
       "name": "Persian",
       "native": "فارسی",
       "rtl": true,
@@ -253,6 +287,7 @@
     },
     {
       "code": "pl",
+      "bcp47": "pl",
       "name": "Polish",
       "native": "Polski",
       "rtl": false,
@@ -260,6 +295,7 @@
     },
     {
       "code": "pt",
+      "bcp47": "pt",
       "name": "Portuguese",
       "native": "Português",
       "rtl": false,
@@ -267,6 +303,7 @@
     },
     {
       "code": "ro",
+      "bcp47": "ro",
       "name": "Romanian",
       "native": "Română",
       "rtl": false,
@@ -274,6 +311,7 @@
     },
     {
       "code": "ru",
+      "bcp47": "ru",
       "name": "Russian",
       "native": "Русский",
       "rtl": false,
@@ -281,6 +319,7 @@
     },
     {
       "code": "gd",
+      "bcp47": "gd",
       "name": "Scottish Gaelic",
       "native": "Gàidhlig",
       "rtl": false,
@@ -288,6 +327,7 @@
     },
     {
       "code": "sr",
+      "bcp47": "sr-Cyrl",
       "name": "Serbian",
       "native": "Српски",
       "rtl": false,
@@ -295,6 +335,7 @@
     },
     {
       "code": "si",
+      "bcp47": "si",
       "name": "Sinhala",
       "native": "සිංහල",
       "rtl": false,
@@ -302,6 +343,7 @@
     },
     {
       "code": "es",
+      "bcp47": "es",
       "name": "Spanish",
       "native": "Español",
       "rtl": false,
@@ -309,6 +351,7 @@
     },
     {
       "code": "su",
+      "bcp47": "su",
       "name": "Sundanese",
       "native": "Basa Sunda",
       "rtl": false,
@@ -316,6 +359,7 @@
     },
     {
       "code": "sv",
+      "bcp47": "sv",
       "name": "Swedish",
       "native": "Svenska",
       "rtl": false,
@@ -323,6 +367,7 @@
     },
     {
       "code": "te",
+      "bcp47": "te",
       "name": "Telugu",
       "native": "తెలుగు",
       "rtl": false,
@@ -330,6 +375,7 @@
     },
     {
       "code": "th",
+      "bcp47": "th",
       "name": "Thai",
       "native": "ไทย",
       "rtl": false,
@@ -337,6 +383,7 @@
     },
     {
       "code": "tr",
+      "bcp47": "tr",
       "name": "Turkish",
       "native": "Türkçe",
       "rtl": false,
@@ -344,6 +391,7 @@
     },
     {
       "code": "ur",
+      "bcp47": "ur",
       "name": "Urdu",
       "native": "اردو",
       "rtl": true,
@@ -351,6 +399,7 @@
     },
     {
       "code": "uz",
+      "bcp47": "uz-Latn",
       "name": "Uzbek",
       "native": "O'zbek",
       "rtl": false,
@@ -358,6 +407,7 @@
     },
     {
       "code": "vi",
+      "bcp47": "vi",
       "name": "Vietnamese",
       "native": "Tiếng Việt",
       "rtl": false,
@@ -365,6 +415,7 @@
     },
     {
       "code": "cy",
+      "bcp47": "cy",
       "name": "Welsh",
       "native": "Cymraeg",
       "rtl": false,

--- a/src/data/language-packs.json
+++ b/src/data/language-packs.json
@@ -1,0 +1,374 @@
+{
+  "_comment": "GENERATED FILE — do not edit by hand. Regenerate with `npm run sync:languages`. Source: the language registry and the canon export manifest in the packs monorepo.",
+  "artifact": "legesher/language-packs",
+  "layer": "canon",
+  "license": "apache-2.0",
+  "counts": {
+    "locales": 51,
+    "packFiles": 255,
+    "vocabularyRows": 46512,
+    "pythonVersions": 5
+  },
+  "tierCounts": {
+    "experimental": 51
+  },
+  "languages": [
+    {
+      "code": "am",
+      "name": "Amharic",
+      "native": "አማርኛ",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ar",
+      "name": "Arabic",
+      "native": "العربية",
+      "rtl": true,
+      "tier": "experimental"
+    },
+    {
+      "code": "bn",
+      "name": "Bengali",
+      "native": "বাংলা",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "bs",
+      "name": "Bosnian",
+      "native": "Bosanski",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "my",
+      "name": "Burmese",
+      "native": "မြန်မာ",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ca",
+      "name": "Catalan",
+      "native": "Català",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "zh",
+      "name": "Chinese",
+      "native": "中文",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "hr",
+      "name": "Croatian",
+      "native": "Hrvatski",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "cs",
+      "name": "Czech",
+      "native": "Čeština",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "da",
+      "name": "Danish",
+      "native": "Dansk",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "nl",
+      "name": "Dutch",
+      "native": "Nederlands",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "en",
+      "name": "English",
+      "native": "English",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "fi",
+      "name": "Finnish",
+      "native": "Suomi",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "fr",
+      "name": "French",
+      "native": "Français",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "gl",
+      "name": "Galician",
+      "native": "Galego",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "de",
+      "name": "German",
+      "native": "Deutsch",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "el",
+      "name": "Greek",
+      "native": "Ελληνικά",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "gu",
+      "name": "Gujarati",
+      "native": "ગુજરાતી",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "he",
+      "name": "Hebrew",
+      "native": "עברית",
+      "rtl": true,
+      "tier": "experimental"
+    },
+    {
+      "code": "hi",
+      "name": "Hindi",
+      "native": "हिन्दी",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "hu",
+      "name": "Hungarian",
+      "native": "Magyar",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "id",
+      "name": "Indonesian",
+      "native": "Bahasa Indonesia",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ga",
+      "name": "Irish",
+      "native": "Gaeilge",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "it",
+      "name": "Italian",
+      "native": "Italiano",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ja",
+      "name": "Japanese",
+      "native": "日本語",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "kn",
+      "name": "Kannada",
+      "native": "ಕನ್ನಡ",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ko",
+      "name": "Korean",
+      "native": "한국어",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "lv",
+      "name": "Latvian",
+      "native": "Latviešu",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "mk",
+      "name": "Macedonian",
+      "native": "Македонски",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ms",
+      "name": "Malay",
+      "native": "Bahasa Melayu",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ml",
+      "name": "Malayalam",
+      "native": "മലയാളം",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "mn",
+      "name": "Mongolian",
+      "native": "Монгол",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "no",
+      "name": "Norwegian",
+      "native": "Norsk",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "fa",
+      "name": "Persian",
+      "native": "فارسی",
+      "rtl": true,
+      "tier": "experimental"
+    },
+    {
+      "code": "pl",
+      "name": "Polish",
+      "native": "Polski",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "pt",
+      "name": "Portuguese",
+      "native": "Português",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ro",
+      "name": "Romanian",
+      "native": "Română",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ru",
+      "name": "Russian",
+      "native": "Русский",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "gd",
+      "name": "Scottish Gaelic",
+      "native": "Gàidhlig",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "sr",
+      "name": "Serbian",
+      "native": "Српски",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "si",
+      "name": "Sinhala",
+      "native": "සිංහල",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "es",
+      "name": "Spanish",
+      "native": "Español",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "su",
+      "name": "Sundanese",
+      "native": "Basa Sunda",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "sv",
+      "name": "Swedish",
+      "native": "Svenska",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "te",
+      "name": "Telugu",
+      "native": "తెలుగు",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "th",
+      "name": "Thai",
+      "native": "ไทย",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "tr",
+      "name": "Turkish",
+      "native": "Türkçe",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "ur",
+      "name": "Urdu",
+      "native": "اردو",
+      "rtl": true,
+      "tier": "experimental"
+    },
+    {
+      "code": "uz",
+      "name": "Uzbek",
+      "native": "O'zbek",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "vi",
+      "name": "Vietnamese",
+      "native": "Tiếng Việt",
+      "rtl": false,
+      "tier": "experimental"
+    },
+    {
+      "code": "cy",
+      "name": "Welsh",
+      "native": "Cymraeg",
+      "rtl": false,
+      "tier": "experimental"
+    }
+  ]
+}

--- a/src/lib/language-packs.ts
+++ b/src/lib/language-packs.ts
@@ -1,0 +1,86 @@
+// Everything the site says about which languages ship and how far each one has
+// been reviewed, read from one generated file.
+//
+// `src/data/language-packs.json` is produced by `npm run sync:languages` from
+// the language registry and the pack export's own manifest — the same two
+// inputs the published dataset is built from. Nothing here retypes a figure:
+// the counts, the tier of each language, and the sentence describing the spread
+// across tiers are all derived, so the site cannot claim a review standard the
+// packs do not hold.
+import data from '@/data/language-packs.json';
+
+export type Tier = 'experimental' | 'reviewed' | 'official';
+
+export interface LanguageEntry {
+  code: string;
+  name: string;
+  native: string;
+  rtl: boolean;
+  tier: Tier;
+}
+
+export const LANGUAGES = data.languages as LanguageEntry[];
+export const COUNTS = data.counts;
+export const TIER_COUNTS = data.tierCounts as Partial<Record<Tier, number>>;
+/** SPDX identifier as declared by the export, e.g. 'apache-2.0'. */
+export const LICENSE = data.license;
+
+/**
+ * The ladder, in order.
+ *
+ * `asserts` and `withholds` are held to the wording of the maturity ladder the
+ * packs themselves document and the dataset card renders. A paraphrase here
+ * would read as a second, subtly different promise about the same stamp.
+ */
+export const TIER_LADDER: {
+  tier: Tier;
+  asserts: string;
+  withholds: string;
+}[] = [
+  {
+    tier: 'experimental',
+    asserts:
+      'Machine-drafted, then curated by maintainers and passed through the mechanical gates: identifier validity, cross-section collision checks, Unicode normalization, schema validation, and a regeneration check proving the shipped pack matches its source of truth.',
+    withholds: 'That any native speaker has seen it.',
+  },
+  {
+    tier: 'reviewed',
+    asserts: 'A native speaker of the language has reviewed the pack and signed off on it.',
+    withholds:
+      'That the terminology has been screened for offensive or unfortunate readings.',
+  },
+  {
+    tier: 'official',
+    asserts:
+      'Certified review plus term screening: a convened session ratifies the pack, and the terminology has been checked for offensive or unfortunate readings.',
+    withholds: '—',
+  },
+];
+
+/** 'experimental → reviewed → official' */
+export const TIER_SEQUENCE = TIER_LADDER.map((stage) => stage.tier).join(' → ');
+
+/**
+ * How the languages are actually distributed across the ladder, in words.
+ *
+ * Derived rather than written, because the honest sentence changes the day a
+ * language is promoted, and a hand-written one would not. While every language
+ * sits on a single rung the sentence says exactly that instead of implying a
+ * spread that does not exist.
+ */
+export function tierSpreadSentence(): string {
+  const present = TIER_LADDER.filter((stage) => (TIER_COUNTS[stage.tier] ?? 0) > 0);
+  if (present.length === 1) {
+    const [only] = present;
+    return `All ${COUNTS.locales} languages are stamped ${only.tier}.`;
+  }
+  const parts = present.map((stage) => `${TIER_COUNTS[stage.tier]} ${stage.tier}`);
+  const spread =
+    parts.length > 1 ? `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}` : parts[0];
+  return `Of ${COUNTS.locales} languages: ${spread}.`;
+}
+
+/** 46512 -> '46,512' */
+export function formatCount(value: number): string {
+  return value.toLocaleString('en-US');
+}

--- a/src/lib/language-packs.ts
+++ b/src/lib/language-packs.ts
@@ -12,7 +12,10 @@ import data from '@/data/language-packs.json';
 export type Tier = 'experimental' | 'reviewed' | 'official';
 
 export interface LanguageEntry {
+  /** Registry key. The pack identifier — what you install and what the dataset keys on. */
   code: string;
+  /** BCP 47 tag. Differs from `code` where a script subtag is needed (`zh` -> `zh-Hans`). */
+  bcp47: string;
   name: string;
   native: string;
   rtl: boolean;
@@ -45,6 +48,11 @@ export const TIER_LADDER: {
   },
   {
     tier: 'reviewed',
+    /**
+     * Singular and in this exact form everywhere it appears on the site: this
+     * is the ladder's own phrasing, and "speakers have endorsed it" elsewhere
+     * would read as a second, stricter bar than the one actually documented.
+     */
     asserts: 'A native speaker of the language has reviewed the pack and signed off on it.',
     withholds:
       'That the terminology has been screened for offensive or unfortunate readings.',
@@ -60,6 +68,26 @@ export const TIER_LADDER: {
 /** 'experimental → reviewed → official' */
 export const TIER_SEQUENCE = TIER_LADDER.map((stage) => stage.tier).join(' → ');
 
+/** The rungs that actually have languages on them, in ladder order. */
+export const TIERS_PRESENT: Tier[] = TIER_LADDER.filter(
+  (stage) => (TIER_COUNTS[stage.tier] ?? 0) > 0
+).map((stage) => stage.tier);
+
+/**
+ * The one tier every language currently carries, or null once they are spread.
+ *
+ * The pages use this to gate the paragraphs that only make sense while the
+ * whole set sits on a single rung — "no native speaker has signed off", "no
+ * criterion has been exercised yet". Those sentences are true today and become
+ * false the first time a language is promoted, and a promotion is a data change
+ * that reaches the site without anyone editing prose. Gating them means the
+ * page loses a paragraph rather than contradicting the table above it.
+ */
+export const ONLY_TIER: Tier | null = TIERS_PRESENT.length === 1 ? TIERS_PRESENT[0] : null;
+
+/** True while nothing has been promoted off the bottom rung. */
+export const ALL_EXPERIMENTAL = ONLY_TIER === 'experimental';
+
 /**
  * How the languages are actually distributed across the ladder, in words.
  *
@@ -69,15 +97,35 @@ export const TIER_SEQUENCE = TIER_LADDER.map((stage) => stage.tier).join(' → '
  * spread that does not exist.
  */
 export function tierSpreadSentence(): string {
-  const present = TIER_LADDER.filter((stage) => (TIER_COUNTS[stage.tier] ?? 0) > 0);
-  if (present.length === 1) {
-    const [only] = present;
-    return `All ${COUNTS.locales} languages are stamped ${only.tier}.`;
+  const parts = TIERS_PRESENT.map((tier) => `${TIER_COUNTS[tier]} ${tier}`);
+  // Unreachable with real data — a generated file with no languages in it would
+  // have failed the sync script's cross-check — but a sentence is a poor place
+  // to discover that, so say nothing rather than "Of 0 languages: undefined."
+  if (parts.length === 0) return '';
+  if (parts.length === 1) {
+    return `All ${COUNTS.locales} languages are stamped ${TIERS_PRESENT[0]}.`;
   }
-  const parts = present.map((stage) => `${TIER_COUNTS[stage.tier]} ${stage.tier}`);
-  const spread =
-    parts.length > 1 ? `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}` : parts[0];
+  const spread = `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}`;
   return `Of ${COUNTS.locales} languages: ${spread}.`;
+}
+
+/**
+ * Whether an endonym is written in the Arabic script.
+ *
+ * Derived from the string rather than from a list of locales, because the
+ * property being tested is "which glyphs does this cell need", and the registry
+ * records no script field to read instead. globals.css defines `.font-arabic`
+ * (Noto Sans Arabic); the body font covers no Arabic glyphs, so without this
+ * the endonym falls back to whatever the OS happens to have.
+ */
+// Arabic, Arabic Supplement, Arabic Extended-A/B, and the two presentation-form
+// blocks. Escaped rather than written literally so the ranges stay readable and
+// cannot be mangled by an editor that reorders bidirectional text.
+const ARABIC_SCRIPT =
+  /[\u0600-\u06FF\u0750-\u077F\u0870-\u089F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/u;
+
+export function usesArabicScript(text: string): boolean {
+  return ARABIC_SCRIPT.test(text);
 }
 
 /** 46512 -> '46,512' */

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -12,6 +12,10 @@ export const LINKS = {
   github: 'https://github.com/legesher',
   slack: 'https://join.slack.com/t/legesher/shared_invite/zt-370xpp6b9-LYxWVIOF7ujVH5kYnwaGbQ',
   docs: 'https://docs.legesher.io/',
+  // The two published datasets. `canon` is the decision layer — what the packs
+  // ship; `corpus` is the evidence layer — every rendering anyone proposed.
+  canon: 'https://huggingface.co/datasets/legesher/language-packs',
+  corpus: 'https://huggingface.co/datasets/legesher/language-corpus',
   linkedin: 'https://www.linkedin.com/company/legesher',
   instagram: 'https://www.instagram.com/legesher',
   email: 'mailto:hello@legesher.com',

--- a/src/lib/page-dates.mjs
+++ b/src/lib/page-dates.mjs
@@ -10,6 +10,8 @@
 export const LAST_UPDATED = {
   privacy: '2026-08-17',
   terms: '2026-07-14',
+  languages: '2026-08-18',
+  canon: '2026-08-18',
 };
 
 /** '2026-08-10' -> 'August 10, 2026'. The sitemap consumes the ISO form directly. */

--- a/src/pages/canon.astro
+++ b/src/pages/canon.astro
@@ -4,7 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { LINKS } from '@/lib/links';
 import { LAST_UPDATED, formatLastUpdated } from '@/lib/page-dates.mjs';
-import { COUNTS, LICENSE, formatCount, tierSpreadSentence } from '@/lib/language-packs';
+import { ALL_EXPERIMENTAL, COUNTS, LICENSE, formatCount, tierSpreadSentence } from '@/lib/language-packs';
 
 const lastUpdated = formatLastUpdated(LAST_UPDATED.canon);
 
@@ -34,7 +34,7 @@ const licenceLabel = LICENSE.toUpperCase().replace('APACHE-', 'Apache ');
 
 <Layout
   title="The Language Canon — Legesher"
-  description="The vocabulary Legesher actually ships: one rendering per programming concept, in 51 human languages, across five Python versions. The decision layer that sits above the language corpus."
+  description={`The vocabulary Legesher actually ships: one rendering per programming concept, in ${COUNTS.locales} human languages, across ${COUNTS.pythonVersions} Python versions. The decision layer that sits above the language corpus.`}
 >
   <Header />
   <main class="pt-32 pb-20 bg-white">
@@ -150,11 +150,29 @@ const licenceLabel = LICENSE.toUpperCase().replace('APACHE-', 'Apache ');
 
         <section aria-labelledby="maturity">
           <h2 id="maturity">How far this has been reviewed</h2>
+          {/* Gated on the data: the moment a language is promoted, "no native
+              speaker has signed off" stops being true, and it would otherwise
+              keep asserting itself under a heading whose own sentence says
+              otherwise. */}
+          {ALL_EXPERIMENTAL ? (
+            <p>
+              <strong>{spread}</strong> That is not a formality. It means the vocabulary has been drafted, curated
+              by maintainers, and put through mechanical gates &mdash; and that no pack has yet cleared native
+              review as a whole. Treat an <code>experimental</code> pack as a serious starting point that wants
+              native review, not as settled terminology.
+            </p>
+          ) : (
+            <p>
+              <strong>{spread}</strong> An <code>experimental</code> pack has been drafted, curated by maintainers
+              and put through mechanical gates, but has not cleared native review as a whole. Treat one as a
+              serious starting point that wants native review, not as settled terminology.
+            </p>
+          )}
           <p>
-            <strong>{spread}</strong> That is not a formality. It means the vocabulary has been drafted, curated by
-            maintainers, and put through mechanical gates &mdash; and that no native speaker has signed off on it.
-            Treat an <code>experimental</code> pack as a serious starting point that wants native review, not as
-            settled terminology.
+            That is compatible with the corpus already carrying endorsements: an endorsement attaches to a single
+            rendering of a single concept, and plenty have been given. The stamp here is about the pack as a whole
+            &mdash; whether a native speaker has reviewed it end to end and signed off on it &mdash; which is a
+            different, larger thing than any one rendering being endorsed.
           </p>
           <p>
             The stamp on every row here is the same stamp the site carries and the same one the installed pack

--- a/src/pages/canon.astro
+++ b/src/pages/canon.astro
@@ -1,0 +1,192 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { LINKS } from '@/lib/links';
+import { LAST_UPDATED, formatLastUpdated } from '@/lib/page-dates.mjs';
+import { COUNTS, LICENSE, formatCount, tierSpreadSentence } from '@/lib/language-packs';
+
+const lastUpdated = formatLastUpdated(LAST_UPDATED.canon);
+
+// Rendered as the visible link text too. Derived rather than retyped so the URL
+// cannot drift from `links.ts` — a link whose label disagrees with its href is
+// exactly the failure that file exists to prevent.
+const bare = (url: string) => url.replace(/^https:\/\//, '');
+
+// Read from src/data/language-packs.json, which the pack export generates. The
+// figures on this page and the figures on the dataset card have one source.
+const FIGURES = [
+  { value: formatCount(COUNTS.locales), label: 'languages' },
+  { value: formatCount(COUNTS.packFiles), label: 'pack files' },
+  { value: formatCount(COUNTS.vocabularyRows), label: 'rows' },
+  { value: formatCount(COUNTS.pythonVersions), label: 'Python versions' },
+];
+
+// The tiles paint with `bg-brand-light-gray` / `text-brand-gray` rather than the
+// `bg-card` / `text-muted-foreground` semantic utilities. Those resolve through
+// `hsl(var(--card))`, but globals.css defines `--card` as a hex, so the browser
+// sees `hsl(#f6f6f6)`, discards it as invalid, and paints nothing.
+const spread = tierSpreadSentence();
+
+// SPDX identifiers are lowercase by convention; prose is not.
+const licenceLabel = LICENSE.toUpperCase().replace('APACHE-', 'Apache ');
+---
+
+<Layout
+  title="The Language Canon — Legesher"
+  description="The vocabulary Legesher actually ships: one rendering per programming concept, in 51 human languages, across five Python versions. The decision layer that sits above the language corpus."
+>
+  <Header />
+  <main class="pt-32 pb-20 bg-white">
+    <div class="container mx-auto px-4 max-w-4xl">
+      <header class="mb-12">
+        <h1 class="text-4xl md:text-5xl font-bold mb-4">The language canon</h1>
+        <p class="text-xl text-brand-gray mb-2">
+          The words Legesher ships: Python&rsquo;s keywords, builtins, exceptions and reserved words, rendered in
+          {COUNTS.locales} human languages across {COUNTS.pythonVersions} interpreter versions. One rendering per
+          concept &mdash; the one you get when you write <code class="font-mono">import legesher</code>.
+        </p>
+        <p class="text-sm text-brand-gray">
+          <span>Last updated: {lastUpdated}</span>
+        </p>
+      </header>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-16">
+        {FIGURES.map((figure) => (
+          <div class="bg-brand-light-gray border border-brand-gray/30 p-4 text-center">
+            <div class="text-2xl md:text-3xl font-bold text-brand-cyan">{figure.value}</div>
+            <div class="text-sm text-brand-gray">{figure.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <article class="prose prose-lg max-w-none prose-headings:text-foreground prose-a:text-brand-cyan hover:prose-a:text-brand-coral prose-table:text-sm">
+        {/* First thing on the page, deliberately. Two similarly named datasets
+            were published days apart, and a reader who has to open both cards
+            to work out which one they want has already been failed. The wording
+            is held word-for-word with the dataset card's own answer to the same
+            question — one distinction, stated once. */}
+        <section aria-labelledby="corpus-or-canon">
+          <h2 id="corpus-or-canon">Corpus or canon &mdash; which one do I want?</h2>
+          <p>
+            <strong>The corpus is the evidence; the canon is the decision.</strong>
+            <a href={LINKS.corpus} target="_blank" rel="noopener noreferrer"
+              ><code class="font-mono">legesher/language-corpus</code></a
+            > records every rendering anyone proposed for a programming concept &mdash; append-only, with the
+            endorsements attached to it. The canon dataset records the one rendering per concept that Legesher
+            actually ships in its language packs: what you get when you write
+            <code class="font-mono">import legesher</code>.
+          </p>
+          <p>
+            Take the canon if you want the words Legesher ships. Take the corpus if you want the evidence behind
+            them, including the renderings that were proposed and not chosen.
+          </p>
+          <div class="not-prose grid gap-4 md:grid-cols-2 my-8">
+            <div class="bg-brand-light-gray border border-brand-gray/30 p-5">
+              <div class="text-xs font-bold uppercase tracking-wide text-brand-coral mb-2">
+                For developers
+              </div>
+              <div class="font-bold mb-1">The canon &mdash; language packs</div>
+              <p class="text-sm text-brand-gray mb-3">
+                The rendering Legesher ships, per concept, per language. What your editor and your interpreter
+                actually use.
+              </p>
+              <a
+                href={LINKS.canon}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm font-medium text-brand-cyan hover:text-brand-coral transition-colors duration-300 break-words"
+                >{bare(LINKS.canon)}</a
+              >
+            </div>
+            <div class="bg-brand-light-gray border border-brand-gray/30 p-5">
+              <div class="text-xs font-bold uppercase tracking-wide text-brand-coral mb-2">
+                For researchers
+              </div>
+              <div class="font-bold mb-1">The corpus &mdash; every proposal</div>
+              <p class="text-sm text-brand-gray mb-3">
+                Every candidate rendering anyone offered and every endorsement a native speaker attached to it,
+                including the ones that were not chosen.
+              </p>
+              <a
+                href={LINKS.corpus}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-sm font-medium text-brand-cyan hover:text-brand-coral transition-colors duration-300 break-words"
+                >{bare(LINKS.corpus)}</a
+              >
+            </div>
+          </div>
+        </section>
+
+        <section aria-labelledby="what-is-in-it">
+          <h2 id="what-is-in-it">What is in it</h2>
+          <p>
+            One row per language, interpreter version, category and source term:
+            {formatCount(COUNTS.vocabularyRows)} rows drawn from {formatCount(COUNTS.packFiles)} pack files.
+            Categories are keywords, builtins, exceptions and reserved words. Alongside the vocabulary, a second
+            table gives one row per language: its identity codes, its script properties, its maturity stamp and its
+            term counts.
+          </p>
+          <p>
+            Rows are given <strong>resolved</strong>. Packs for newer interpreter versions carry only a delta and
+            inherit the rest, so a naive reading of the pack files would tell you Python 3.14 has a handful of
+            words in it. Each row instead states what you would actually get on that interpreter, while keeping the
+            delta structure visible: every row records the version whose pack file defines the term, and whether it
+            was inherited rather than defined there. The vocabulary grows with the language, which is why the term
+            count differs by version at all.
+          </p>
+          <p>
+            The dataset is generated from the pack tree, not from the selection database behind it. That is a
+            deliberate constraint: the database also holds selections for other targets, and sourcing from it would
+            publish terminology this dataset does not claim to cover. Every file carries a checksum and the
+            toolchain that produced it, so the export is reproducible rather than asserted.
+          </p>
+          <p>
+            Parquet for the two tables, plus a plain JSON mirror of each resolved pack for anyone who would rather
+            not read Parquet.
+          </p>
+        </section>
+
+        <section aria-labelledby="maturity">
+          <h2 id="maturity">How far this has been reviewed</h2>
+          <p>
+            <strong>{spread}</strong> That is not a formality. It means the vocabulary has been drafted, curated by
+            maintainers, and put through mechanical gates &mdash; and that no native speaker has signed off on it.
+            Treat an <code>experimental</code> pack as a serious starting point that wants native review, not as
+            settled terminology.
+          </p>
+          <p>
+            The stamp on every row here is the same stamp the site carries and the same one the installed pack
+            carries. <a href="/languages">The language support page</a> lists where each language stands, explains
+            the ladder, and says what moves a language up it.
+          </p>
+        </section>
+
+        <section aria-labelledby="licence">
+          <h2 id="licence">Licence</h2>
+          <p>
+            {licenceLabel}, matching the package the language packs ship in. The corpus is licensed separately,
+            under CC BY 4.0 &mdash; the two datasets serve different purposes and carry different terms, so check
+            the one you are actually using.
+          </p>
+        </section>
+
+        <section aria-labelledby="get-the-data">
+          <h2 id="get-the-data">Get the data</h2>
+          <p>
+            <a href={LINKS.canon} target="_blank" rel="noopener noreferrer" class="break-words"
+              >{bare(LINKS.canon)}</a
+            >
+          </p>
+          <p>
+            If you speak one of these languages and a rendering is wrong, we would rather know.
+            <a href={LINKS.slack} target="_blank" rel="noopener noreferrer">Find us in Slack</a> or open an issue on
+            <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>.
+          </p>
+        </section>
+      </article>
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/languages.astro
+++ b/src/pages/languages.astro
@@ -5,12 +5,14 @@ import Footer from '../components/Footer.astro';
 import { LINKS } from '@/lib/links';
 import { LAST_UPDATED, formatLastUpdated } from '@/lib/page-dates.mjs';
 import {
+  ALL_EXPERIMENTAL,
   COUNTS,
   LANGUAGES,
   TIER_LADDER,
   TIER_SEQUENCE,
   formatCount,
   tierSpreadSentence,
+  usesArabicScript,
 } from '@/lib/language-packs';
 
 const lastUpdated = formatLastUpdated(LAST_UPDATED.languages);
@@ -22,7 +24,11 @@ const lastUpdated = formatLastUpdated(LAST_UPDATED.languages);
 const FIGURES = [
   { value: formatCount(COUNTS.locales), label: 'languages' },
   { value: formatCount(COUNTS.packFiles), label: 'pack files' },
-  { value: formatCount(COUNTS.vocabularyRows), label: 'terms' },
+  // Rows, not terms. A language carries roughly 184 source terms; the row count
+  // is those terms resolved across every interpreter version, so labelling it
+  // "terms" would overstate the vocabulary by a factor of five. Same label as
+  // the canon page uses for the same number.
+  { value: formatCount(COUNTS.vocabularyRows), label: 'vocabulary rows' },
   { value: formatCount(COUNTS.pythonVersions), label: 'Python versions' },
 ];
 
@@ -63,18 +69,30 @@ const spread = tierSpreadSentence();
       <article class="prose prose-lg max-w-none prose-headings:text-foreground prose-a:text-brand-cyan hover:prose-a:text-brand-coral prose-table:text-sm">
         <section aria-labelledby="where-we-are">
           <h2 id="where-we-are">Where every language stands today</h2>
-          <p>
-            <strong>{spread}</strong> Nothing has been promoted, so no pack currently carries
-            <code>reviewed</code> or <code>official</code>. We would rather say that plainly than present a ladder
-            and let you assume the languages are spread across it.
-          </p>
+          {/* The "nothing has been promoted" claim is gated on the data rather
+              than written flat. A promotion reaches this page as a changed tier
+              in the generated file, with no prose edit attached, and an
+              ungated paragraph would go on denying it directly above a table
+              showing otherwise. */}
+          {ALL_EXPERIMENTAL ? (
+            <p>
+              <strong>{spread}</strong> Nothing has been promoted, so no pack currently carries
+              <code>reviewed</code> or <code>official</code>. We would rather say that plainly than present a ladder
+              and let you assume the languages are spread across it.
+            </p>
+          ) : (
+            <p>
+              <strong>{spread}</strong> The stage each language sits at is listed below, and what each stage means
+              is set out in the ladder that follows.
+            </p>
+          )}
           <p>
             <code>experimental</code> is not <em>unchecked</em>. Every shipped pack has been drafted, curated by
             maintainers, and put through mechanical gates that are real work and catch real defects. What those
             gates cannot do is tell you whether a developer who speaks the language would ever use the word. A gate
             can prove a term is a valid identifier that collides with nothing; only a native speaker can say it
-            reads right. That distinction is the whole reason the ladder exists, and it is why
-            <code>experimental</code> is the honest stamp for all of them today.
+            reads right. That distinction is the whole reason the ladder exists, and it is what a language leaves
+            <code>experimental</code> by clearing.
           </p>
         </section>
 
@@ -84,22 +102,24 @@ const spread = tierSpreadSentence();
             Three stages, <code>{TIER_SEQUENCE}</code>. Each one asserts something specific and withholds something
             specific, so a stamp tells you what has been done and what has not.
           </p>
-          {/* The only wide element on the page besides the language table.
-              Scrolling it inside its own box keeps a narrow screen from having
-              to scroll the whole document sideways to read one cell. */}
-          <div class="overflow-x-auto">
+          {/* Scrolling the table inside its own box keeps a narrow screen from
+              having to scroll the whole document sideways to read one cell.
+              tabindex + role make that box reachable by keyboard: it has no
+              focusable child, so without them a keyboard-only reader cannot
+              scroll it at all (WCAG 2.1.1). */}
+          <div class="overflow-x-auto" tabindex="0" role="region" aria-label="Maturity ladder">
             <table class="min-w-[34rem]">
               <thead>
                 <tr>
-                  <th>Stage</th>
-                  <th>What it asserts</th>
-                  <th>What it does not assert</th>
+                  <th scope="col">Stage</th>
+                  <th scope="col">What it asserts</th>
+                  <th scope="col">What it does not assert</th>
                 </tr>
               </thead>
               <tbody>
                 {TIER_LADDER.map((stage) => (
                   <tr>
-                    <td><code>{stage.tier}</code></td>
+                    <th scope="row" class="align-baseline font-normal py-[0.5714286em] pe-[0.5714286em] ps-0"><code>{stage.tier}</code></th>
                     <td>{stage.asserts}</td>
                     <td>{stage.withholds}</td>
                   </tr>
@@ -112,9 +132,10 @@ const spread = tierSpreadSentence();
         <section aria-labelledby="promotion">
           <h2 id="promotion">What moves a language up</h2>
           <p>
-            Native review. A pack leaves <code>experimental</code> when speakers of the language have read the
-            vocabulary and endorsed it, and it reaches <code>official</code> when that review is certified and the
-            terminology has additionally been screened for readings a speaker would not want in their editor.
+            Native review. A pack leaves <code>experimental</code> when a native speaker of the language has
+            reviewed it and signed off on it, and it reaches <code>official</code> when that review is certified
+            and the terminology has additionally been screened for readings a speaker would not want in their
+            editor.
           </p>
           <p>
             <strong>The precise criteria are still being defined, and we are defining them with the communities the
@@ -122,7 +143,7 @@ const spread = tierSpreadSentence();
             have to be, how much of a pack must be reviewed before the pack itself counts as reviewed, and who
             certifies <code>official</code>. Those are questions about what a language community considers
             sufficient, and answering them in private would produce a threshold that means nothing to the people it
-            is meant to reassure. Nothing has been promoted yet, so no criterion has been exercised in production.
+            is meant to reassure.{ALL_EXPERIMENTAL && ' Nothing has been promoted yet, so no criterion has been exercised in production.'}
           </p>
           <p>
             If you speak one of these languages and something in a pack is wrong, that is the contribution that
@@ -136,26 +157,35 @@ const spread = tierSpreadSentence();
           <p>
             Each ships as a language pack covering Python&rsquo;s keywords, builtins, exceptions and reserved words
             across {COUNTS.pythonVersions} interpreter versions. The stamp below is the same one carried by the
-            pack you install and by the row in the published dataset.
+            pack you install and by the dataset row.
           </p>
-          <div class="overflow-x-auto">
+          <div class="overflow-x-auto" tabindex="0" role="region" aria-label="Languages and their stages">
             <table class="min-w-[30rem]">
               <thead>
                 <tr>
-                  <th>Language</th>
-                  <th>In that language</th>
-                  <th>Code</th>
-                  <th>Stage</th>
+                  <th scope="col">Language</th>
+                  <th scope="col">In that language</th>
+                  <th scope="col">Code</th>
+                  <th scope="col">Stage</th>
                 </tr>
               </thead>
               <tbody>
                 {LANGUAGES.map((language) => (
                   <tr>
-                    <td>{language.name}</td>
-                    {/* lang/dir so a screen reader announces the endonym in its
-                        own language, and so right-to-left scripts are laid out
-                        the way their readers write them. */}
-                    <td lang={language.code} dir={language.rtl ? 'rtl' : 'ltr'}>{language.native}</td>
+                    <th scope="row" class="align-baseline font-normal py-[0.5714286em] pe-[0.5714286em] ps-0">{language.name}</th>
+                    {/* `lang` carries the BCP 47 tag, not the registry key: the
+                        two differ for five languages, and it is the tag that
+                        tells a screen reader which voice to use and a browser
+                        which font to reach for. `dir` lays right-to-left
+                        scripts out the way their readers write them, and
+                        `.font-arabic` supplies the Arabic coverage the body
+                        font does not have. */}
+                    <td
+                      lang={language.bcp47}
+                      dir={language.rtl ? 'rtl' : 'ltr'}
+                      class={usesArabicScript(language.native) ? 'font-arabic' : undefined}
+                      >{language.native}</td
+                    >
                     <td><code>{language.code}</code></td>
                     <td><code>{language.tier}</code></td>
                   </tr>
@@ -169,12 +199,12 @@ const spread = tierSpreadSentence();
           <h2 id="the-data">Where this comes from</h2>
           <p>
             The table above is not maintained by hand. It is generated from the language registry and from the
-            export that produces the published dataset, so a stamp changes here because it changed there &mdash;
-            the page cannot claim a language has been reviewed when the shipped pack says otherwise.
+            export that produces the canon dataset, so a stamp changes here because it changed there &mdash; the
+            page cannot claim a language has been reviewed when the shipped pack says otherwise.
           </p>
           <p>
-            The vocabulary itself is published as <a href="/canon">the canon dataset</a> &mdash; the one rendering
-            per concept that Legesher ships &mdash; alongside
+            The vocabulary itself ships as the canon dataset: one rendering per concept, the one your interpreter
+            actually uses. <a href="/canon">The language canon page</a> covers that dataset and how it differs from
             <a href={LINKS.corpus} target="_blank" rel="noopener noreferrer">the language corpus</a>, which records
             every rendering anyone proposed and the endorsements attached to each.
           </p>

--- a/src/pages/languages.astro
+++ b/src/pages/languages.astro
@@ -1,0 +1,186 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { LINKS } from '@/lib/links';
+import { LAST_UPDATED, formatLastUpdated } from '@/lib/page-dates.mjs';
+import {
+  COUNTS,
+  LANGUAGES,
+  TIER_LADDER,
+  TIER_SEQUENCE,
+  formatCount,
+  tierSpreadSentence,
+} from '@/lib/language-packs';
+
+const lastUpdated = formatLastUpdated(LAST_UPDATED.languages);
+
+// Every figure on this page is read from src/data/language-packs.json, which is
+// generated from the same registry and export manifest the published dataset is
+// built from. Retyping any of them here is how the stamp on the site and the
+// stamp on the dataset would drift apart.
+const FIGURES = [
+  { value: formatCount(COUNTS.locales), label: 'languages' },
+  { value: formatCount(COUNTS.packFiles), label: 'pack files' },
+  { value: formatCount(COUNTS.vocabularyRows), label: 'terms' },
+  { value: formatCount(COUNTS.pythonVersions), label: 'Python versions' },
+];
+
+// The tiles paint with `bg-brand-light-gray` / `text-brand-gray` rather than the
+// `bg-card` / `text-muted-foreground` semantic utilities. Those resolve through
+// `hsl(var(--card))`, but globals.css defines `--card` as a hex, so the browser
+// sees `hsl(#f6f6f6)`, discards it as invalid, and paints nothing.
+const spread = tierSpreadSentence();
+---
+
+<Layout
+  title="Language support — Legesher"
+  description="Which human languages Legesher ships a Python language pack for, what maturity stamp each one carries, and what moves a language up the ladder."
+>
+  <Header />
+  <main class="pt-32 pb-20 bg-white">
+    <div class="container mx-auto px-4 max-w-4xl">
+      <header class="mb-12">
+        <h1 class="text-4xl md:text-5xl font-bold mb-4">Language support</h1>
+        <p class="text-xl text-brand-gray mb-2">
+          The human languages you can write Python in today, and how far the vocabulary of each one has been
+          reviewed. {spread}
+        </p>
+        <p class="text-sm text-brand-gray">
+          <span>Last updated: {lastUpdated}</span>
+        </p>
+      </header>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-16">
+        {FIGURES.map((figure) => (
+          <div class="bg-brand-light-gray border border-brand-gray/30 p-4 text-center">
+            <div class="text-2xl md:text-3xl font-bold text-brand-cyan">{figure.value}</div>
+            <div class="text-sm text-brand-gray">{figure.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <article class="prose prose-lg max-w-none prose-headings:text-foreground prose-a:text-brand-cyan hover:prose-a:text-brand-coral prose-table:text-sm">
+        <section aria-labelledby="where-we-are">
+          <h2 id="where-we-are">Where every language stands today</h2>
+          <p>
+            <strong>{spread}</strong> Nothing has been promoted, so no pack currently carries
+            <code>reviewed</code> or <code>official</code>. We would rather say that plainly than present a ladder
+            and let you assume the languages are spread across it.
+          </p>
+          <p>
+            <code>experimental</code> is not <em>unchecked</em>. Every shipped pack has been drafted, curated by
+            maintainers, and put through mechanical gates that are real work and catch real defects. What those
+            gates cannot do is tell you whether a developer who speaks the language would ever use the word. A gate
+            can prove a term is a valid identifier that collides with nothing; only a native speaker can say it
+            reads right. That distinction is the whole reason the ladder exists, and it is why
+            <code>experimental</code> is the honest stamp for all of them today.
+          </p>
+        </section>
+
+        <section aria-labelledby="the-ladder">
+          <h2 id="the-ladder">The maturity ladder</h2>
+          <p>
+            Three stages, <code>{TIER_SEQUENCE}</code>. Each one asserts something specific and withholds something
+            specific, so a stamp tells you what has been done and what has not.
+          </p>
+          {/* The only wide element on the page besides the language table.
+              Scrolling it inside its own box keeps a narrow screen from having
+              to scroll the whole document sideways to read one cell. */}
+          <div class="overflow-x-auto">
+            <table class="min-w-[34rem]">
+              <thead>
+                <tr>
+                  <th>Stage</th>
+                  <th>What it asserts</th>
+                  <th>What it does not assert</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TIER_LADDER.map((stage) => (
+                  <tr>
+                    <td><code>{stage.tier}</code></td>
+                    <td>{stage.asserts}</td>
+                    <td>{stage.withholds}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section aria-labelledby="promotion">
+          <h2 id="promotion">What moves a language up</h2>
+          <p>
+            Native review. A pack leaves <code>experimental</code> when speakers of the language have read the
+            vocabulary and endorsed it, and it reaches <code>official</code> when that review is certified and the
+            terminology has additionally been screened for readings a speaker would not want in their editor.
+          </p>
+          <p>
+            <strong>The precise criteria are still being defined, and we are defining them with the communities the
+            stamps describe</strong> &mdash; how many endorsements a term needs, how varied the voices behind them
+            have to be, how much of a pack must be reviewed before the pack itself counts as reviewed, and who
+            certifies <code>official</code>. Those are questions about what a language community considers
+            sufficient, and answering them in private would produce a threshold that means nothing to the people it
+            is meant to reassure. Nothing has been promoted yet, so no criterion has been exercised in production.
+          </p>
+          <p>
+            If you speak one of these languages and something in a pack is wrong, that is the contribution that
+            moves it. <a href={LINKS.slack} target="_blank" rel="noopener noreferrer">Find us in Slack</a> or open
+            an issue on <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>.
+          </p>
+        </section>
+
+        <section aria-labelledby="languages">
+          <h2 id="languages">The {COUNTS.locales} languages</h2>
+          <p>
+            Each ships as a language pack covering Python&rsquo;s keywords, builtins, exceptions and reserved words
+            across {COUNTS.pythonVersions} interpreter versions. The stamp below is the same one carried by the
+            pack you install and by the row in the published dataset.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="min-w-[30rem]">
+              <thead>
+                <tr>
+                  <th>Language</th>
+                  <th>In that language</th>
+                  <th>Code</th>
+                  <th>Stage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {LANGUAGES.map((language) => (
+                  <tr>
+                    <td>{language.name}</td>
+                    {/* lang/dir so a screen reader announces the endonym in its
+                        own language, and so right-to-left scripts are laid out
+                        the way their readers write them. */}
+                    <td lang={language.code} dir={language.rtl ? 'rtl' : 'ltr'}>{language.native}</td>
+                    <td><code>{language.code}</code></td>
+                    <td><code>{language.tier}</code></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section aria-labelledby="the-data">
+          <h2 id="the-data">Where this comes from</h2>
+          <p>
+            The table above is not maintained by hand. It is generated from the language registry and from the
+            export that produces the published dataset, so a stamp changes here because it changed there &mdash;
+            the page cannot claim a language has been reviewed when the shipped pack says otherwise.
+          </p>
+          <p>
+            The vocabulary itself is published as <a href="/canon">the canon dataset</a> &mdash; the one rendering
+            per concept that Legesher ships &mdash; alongside
+            <a href={LINKS.corpus} target="_blank" rel="noopener noreferrer">the language corpus</a>, which records
+            every rendering anyone proposed and the endorsements attached to each.
+          </p>
+        </section>
+      </article>
+    </div>
+  </main>
+  <Footer />
+</Layout>


### PR DESCRIPTION
Two pages the published datasets need the website to answer for, and the generated data that keeps the site's claims and the datasets' claims from drifting apart.

## `/languages` — language support (CORE-1929)

Lists every human language Legesher ships a Python language pack for, with the maturity stamp each one carries.

All 51 are `experimental`, and the page states that as a sentence rather than leaving it as a table a reader has to total up. Presenting a three-rung ladder while every language sits on the bottom rung invites the assumption that some of them do not, so the honest reading is made the first thing in the section — and the sentence is derived from the data, so it stops being true the day a language is promoted.

The ladder is explained by what each stage asserts and what it withholds, worded to match the maturity ladder the packs themselves document and the dataset card renders. Promotion criteria are described as still being defined with the language communities, because they are: no numeric threshold appears anywhere on the page. How many endorsements a term needs, how varied the voices behind them must be, how much of a pack must be reviewed before the pack counts as reviewed, and who certifies `official` are all open. A number invented for the website would become the number we are held to.

Scope is the minimum slice: no sponsorship goals, no donate flow, no per-language funding targets.

## `/canon` — the language canon (CORE-1930)

Covers the vocabulary dataset itself. Two similarly named datasets were published days apart, so the first section on the page is the difference between them rather than a description of the contents:

> **The corpus is the evidence; the canon is the decision.**

Both artifacts are linked from that section and each is labelled for who it is for — the canon for developers, the corpus for researchers — so choosing between them does not require opening two dataset cards. The wording matches the canon dataset card's own answer to the same question, which the exporter renders from a pinned constant: one distinction, stated once, in both places. The corpus card does not carry this passage.

The canon dataset URL resolves once that dataset is published. The site content is intended to land ahead of it.

## Data source

Tier state is generated, never typed.

`npm run sync:languages` derives `src/data/language-packs.json` from two inputs: the language registry, and the pack export's own manifest — the same two inputs the published dataset is built from. It cross-checks them and exits non-zero if they name different locales or disagree about the spread across the ladder, so a stale pairing fails at sync time instead of rendering a wrong number. Both flags are required rather than defaulted, because the wrong pairing is worse than no run at all.

Every count and every stamp on both pages reads from that one file. The site therefore cannot advertise a review standard the shipped packs no longer hold, and a future sync is a single command rather than an edit pass over two pages.

The export's parquet files are deliberately not read. Everything rendered is already in the manifest, and adding a parquet dependency to a static site build would only re-derive numbers the exporter has already reconciled.

## Figures

51 languages, 255 pack files, 46,512 vocabulary rows across 5 interpreter versions, Apache-2.0. Reconciled against the export rather than quoted — an earlier count of 52 came from treating a version-index file as a locale.

## Verification

- `npm ci` and `npm run build` green; both routes prerender.
- Sitemap carries `/canon` and `/languages` with correct `lastmod`; canonical and social tags present on both; URLs stay bare.
- 51 rows render, with `lang` and `dir` set per language so endonyms are announced in their own language and right-to-left scripts lay out correctly (4 RTL).
- Both wide tables scroll inside their own containers, so a narrow screen never has to scroll the document sideways. Verified in the built markup rather than by screenshot.
- Neither page uses `bg-card` or `text-muted-foreground`; those resolve through `hsl(var(--card))`, which `globals.css` defines as a hex, so the browser discards the value and paints nothing. The tiles use brand colours directly.
- The sync script is idempotent, and fails closed on both a mismatched locale set and a mismatched tier spread.
- No internal identifiers in rendered output.
- Both tables are keyboard-scrollable named regions with `scope`d column headers and a row header per row; no duplicate ids and no dangling `aria-labelledby` on either page.
- `lang` carries the registry's BCP 47 tag (five differ from the key — `zh`/`zh-Hans`, `no`/`nb`); the visible Code column keeps the key, which is the pack identifier.
- The paragraphs that only hold while every language sits on one rung are gated on the tier data. Exercised by building against a doctored multi-tier data file: the all-experimental copy drops out, the tier-agnostic alternative renders, and the spread sentence reads "Of 51 languages: 48 experimental, 2 reviewed and 1 official". Real data restored and confirmed byte-identical on re-sync.
- The sync script accepts a manifest declaring a rung as zero, and rejects a duplicated locale, a missing `locales` array, missing `counts`, and a file that is not the registry — each with a message naming the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
